### PR TITLE
Add Clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: rust
 rust:
   - stable
   - beta
-  - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
 addons:
   apt:
     update: true
-    packages: xorg-dev  # needed by minifb
+    packages:
+      - xorg-dev # needed by minifb
+before_script:
+  - rustup component add clippy
+script:
+  - cargo clippy --all-targets --all-features -- -D warnings
+  - cargo build --verbose --all
+  - cargo test --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ addons:
 before_script:
   - rustup component add clippy
 script:
-  - cargo clippy --all-targets --all-features -- -D warnings
+  - cargo clippy --all-targets --all-features
   - cargo build --verbose --all
   - cargo test --verbose --all

--- a/src/cel.rs
+++ b/src/cel.rs
@@ -30,9 +30,12 @@ pub struct CelShader<'a> {
 }
 
 impl<'a> Pipeline for CelShader<'a> {
-    type Vertex = u32; // Vertex index
-    type VsOut = Vec3<f32>; // Normal
-    type Pixel = u32; // BGRA
+    // BGRA
+    type Pixel = u32;
+    // Vertex index
+    type Vertex = u32;
+    // Normal
+    type VsOut = Vec3<f32>;
 
     /// The vertex shader that does cel shading.
     ///

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -26,7 +26,7 @@ impl Mesh {
     }
 
     pub fn from_gltf(
-        buffers: &Vec<gltf::buffer::Data>,
+        buffers: &[gltf::buffer::Data],
         primitive: &gltf::Primitive,
         materials: &[Rc<Material>],
     ) -> Self {
@@ -54,12 +54,7 @@ impl Mesh {
             "Position vector and normals vector have different lengths"
         );
 
-        Self {
-            indices: indices,
-            positions: positions,
-            normals: normals,
-            material: material,
-        }
+        Self {indices, positions, normals, material}
     }
 
     /// Returns the indices of this mesh

--- a/src/loaders/gltf.rs
+++ b/src/loaders/gltf.rs
@@ -12,7 +12,7 @@ pub fn load_file(filepath: &str) -> Vec<Mesh> {
     // that primitive refers to is loaded in the same order as document.materials()
     let materials: Vec<_> = document
         .materials()
-        .map(|material| Rc::new(Material::from_gltf(&material)))
+        .map(|material| Rc::new(Material::from(material)))
         .collect();
 
     for mesh in document.meshes() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 //   globally disable that aspect of the tool or live with it and do what the tool says
 // - If we make a mistake and find that one of these lints shouldn't have been added here, we can
 //   always remove it later
+#![deny(clippy::all)] // Deny clippy warnings when running clippy (used for CI)
 #![allow(
     clippy::identity_op,
     clippy::let_and_return,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,21 @@
+//! The main spritec executable
+
+// TOOL POLICY:
+// - We add tools in order to help *us* improve our code
+// - If they are not doing that, we can configure them or even elect to remove them
+// - No tool is perfect and we are allowed to disagree with its results
+// - If the tool warns about something that isn't actually an issue worth caring about, add it to
+//   the list below and explain your change in your PR
+// - We don't want to litter our code with #[allow] attributes unnecessarily, so try to either
+//   globally disable that aspect of the tool or live with it and do what the tool says
+// - If we make a mistake and find that one of these lints shouldn't have been added here, we can
+//   always remove it later
+#![allow(
+    clippy::identity_op,
+    clippy::let_and_return,
+    clippy::cast_lossless,
+)]
+
 mod cel;
 mod color;
 mod geometry;
@@ -63,7 +81,7 @@ fn save_poses(
     let mut color = Buffer2d::new([image_width, image_height], 0);
     let mut depth = Buffer2d::new([image_width, image_height], 1.0);
 
-    for (i, frame) in frames.into_iter().enumerate() {
+    for (i, frame) in frames.iter().enumerate() {
         render(&mut color, &mut depth, model, view, projection, frame, 0.15);
 
         let mut img = ImageBuffer::new(image_width as u32, image_height as u32);
@@ -97,7 +115,7 @@ fn save_spritesheet(
     let mut color = Buffer2d::new([image_width, image_height], 0);
     let mut depth = Buffer2d::new([image_width, image_height], 1.0);
 
-    for (i, frame) in frames.into_iter().enumerate() {
+    for (i, frame) in frames.iter().enumerate() {
         render(&mut color, &mut depth, model, view, projection, frame, 0.15);
 
         let column = i % columns;

--- a/src/material.rs
+++ b/src/material.rs
@@ -5,19 +5,19 @@ pub struct Material {
     pub diffuse_color: Rgba<f32>,
 }
 
-impl Material {
-    pub fn from_gltf(mat: &gltf::Material) -> Self {
-        let [r, g, b, a] = mat.pbr_metallic_roughness().base_color_factor();
-        Self {
-            diffuse_color: Rgba::new(r, g, b, a),
-        }
-    }
-}
-
 impl Default for Material {
     fn default() -> Self {
         Self {
             diffuse_color: Rgba::black(),
+        }
+    }
+}
+
+impl<'a> From<gltf::Material<'a>> for Material {
+    fn from(mat: gltf::Material<'a>) -> Self {
+        let [r, g, b, a] = mat.pbr_metallic_roughness().base_color_factor();
+        Self {
+            diffuse_color: Rgba::new(r, g, b, a),
         }
     }
 }

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -26,9 +26,12 @@ pub struct OutlineShader<'a> {
 }
 
 impl<'a> Pipeline for OutlineShader<'a> {
-    type Vertex = u32; // Vertex index
-    type VsOut = Vec3<f32>; // Normal
-    type Pixel = u32; // BGRA
+    // BGRA
+    type Pixel = u32;
+    // Vertex index
+    type Vertex = u32;
+    // Normal
+    type VsOut = Vec3<f32>;
 
     /// The vertex shader that does the outlines.
     #[inline(always)]


### PR DESCRIPTION
[Clippy](https://github.com/rust-lang/rust-clippy) is a fun tool designed to help us improve the quality of our code. If you've used a "linter" in other languages, clippy is Rust's "linter". Unlike rustfmt which checks/enforces a certain *style* in our codebase, clippy's job is to help us avoid common mistakes. 

It does this by printing helpful messages about potential improvements we can make:

```
warning: this .into_iter() call is equivalent to .iter() and will not move the slice
  --> src/main.rs:85:30
   |
85 |     for (i, frame) in frames.into_iter().enumerate() {
   |                              ^^^^^^^^^ help: call directly: `iter`
   |
   = note: #[warn(clippy::into_iter_on_ref)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_ref

warning: this .into_iter() call is equivalent to .iter() and will not move the slice
   --> src/main.rs:119:30
    |
119 |     for (i, frame) in frames.into_iter().enumerate() {
    |                              ^^^^^^^^^ help: call directly: `iter`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_ref
```

These messages are often very helpful and detailed. You can learn a lot about writing idiomatic Rust from using clippy.

That being said, and as you know from our testing course, all static analysis tools are inherently limited. Clippy is no exception. It can very opinionated at times and this can lead to it warning about things that aren't even really issues. The tool policy (see below) is designed to address that.

## Running clippy locally

To run clippy, you will need to "add" it to your rust installation:

```bash
rustup component add clippy # only need to do this once to install clippy
```

Then you can run clippy using its cargo command:

```bash
cargo clippy
```

## Tool Policy

To deal with the inaccuracies of these tools, I have proposed and documented a "tool policy" to help remind us about why we have these tools and to give *everyone* the freedom to configure them.

The policy is documented at the top of `main.rs`, but I've reproduced it here for your convenience:

- We add tools in order to help *us* improve our code
- If they are not doing that, we can configure them or even elect to remove them
- No tool is perfect and we are allowed to disagree with its results
- If the tool warns about something that isn't actually an issue worth caring about, add it to
  the list below and explain your change in your PR
- We don't want to litter our code with #[allow] attributes unnecessarily, so try to either
  globally disable that aspect of the tool or live with it and do what the tool says
- If we make a mistake and find that one of these lints shouldn't have been added here, we can
  always remove it later

See `main.rs` to understand what "below" means.

---

This policy is carefully worded to empower *everyone* in our group to use your own judgment and not apply the suggestions from clippy blindly.

cc @ProtoArt/core-team 