### PR TITLE
Fix Bug in Config + Add Knight Model Config File

### DIFF
--- a/samples/knight/spritec.toml
+++ b/samples/knight/spritec.toml
@@ -1,0 +1,21 @@
+# Configuration file for generating images with spritec
+#
+# Paths in this file are relative to the location of this configuration file
+
+[[poses]]
+model = "knight.obj"
+path = "../../knight64.png"
+width = 64
+height = 64
+scale = 2
+camera = "PerspectiveFront"
+outline = { thickness = 0.15 }
+
+[[poses]]
+model = "knight.obj"
+path = "../../knight32.png"
+width = 32
+height = 32
+scale = 4
+camera = "PerspectiveFront"
+outline = { thickness = 0.15 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,8 +27,10 @@ impl UnresolvedPath {
 #[serde(deny_unknown_fields)]
 pub struct TaskConfig {
     /// A list of the spritesheets for spritec to generate
+    #[serde(default)]
     pub spritesheets: Vec<Spritesheet>,
     /// A list of individual poses for spritec to generate images for
+    #[serde(default)]
     pub poses: Vec<Pose>,
 }
 


### PR DESCRIPTION
This PR allows the config file to have spritesheets *or* poses (but not necessarily both or either). It also adds a config for the knight model.