### PR TITLE
Removed Adhoc Scaling and Enabled Automatic and Customized Generation of Poses

### DIFF
--- a/spritec-preview/src/main.rs
+++ b/spritec-preview/src/main.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use std::error::Error;
 use std::thread;
 
-use vek::{Mat4, Vec3,Vec4, Rgba};
+use vek::{Mat4, Rgba};
 use euc::{buffer::Buffer2d, Target};
 use minifb::{Window, WindowOptions, Key, KeyRepeat};
 use spritec::{
@@ -38,17 +38,15 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // The transformation that represents the position and orientation of the camera
     //
-
-    // WE GOTTA ESTABLISH A STANDARD HANDEDNESS FOR MODELS
-    // Assume a right-handed system for world
-    let eye = Vec4::new(0.0,-8.5,-1.0,1.0);
-    let target = Vec4::new(0.0,0.0,0.0,1.0);
-
     // World coordinates -> Camera coordinates
-    let view = Mat4::<f32>::look_at_rh(eye, target, Vec4::up());
-    let projection = Mat4::perspective_rh_no(0.35*PI, (image_width as f32)/(image_height as f32), 0.01, 100.0);
+    let view = Mat4::rotation_x(PI/8.0) * Mat4::rotation_y(0.0*PI/2.0);
+    // The perspective/orthographic/etc. projection of the camera
+    //
+    // Camera coordinates -> Homogenous coordinates
+    let projection = Mat4::perspective_rh_no(0.8*PI, (image_width as f32)/(image_height as f32), 0.01, 100.0)
+        * Mat4::<f32>::scaling_3d(0.6);
 
-    let scale = 10;
+    let scale = 16;
     let background = Rgba {r: 0.62, g: 0.62, b: 0.62, a: 1.0};
 
     let mut color = Buffer2d::new([image_width, image_height], background);

--- a/spritec-preview/src/main.rs
+++ b/spritec-preview/src/main.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use std::error::Error;
 use std::thread;
 
-use vek::{Mat4, Rgba};
+use vek::{Mat4, Vec3,Vec4, Rgba};
 use euc::{buffer::Buffer2d, Target};
 use minifb::{Window, WindowOptions, Key, KeyRepeat};
 use spritec::{
@@ -38,15 +38,17 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // The transformation that represents the position and orientation of the camera
     //
-    // World coordinates -> Camera coordinates
-    let view = Mat4::rotation_x(PI/8.0) * Mat4::rotation_y(0.0*PI/2.0);
-    // The perspective/orthographic/etc. projection of the camera
-    //
-    // Camera coordinates -> Homogenous coordinates
-    let projection = Mat4::perspective_rh_no(0.8*PI, (image_width as f32)/(image_height as f32), 0.01, 100.0)
-        * Mat4::<f32>::scaling_3d(0.6);
 
-    let scale = 16;
+    // WE GOTTA ESTABLISH A STANDARD HANDEDNESS FOR MODELS
+    // Assume a right-handed system for world
+    let eye = Vec4::new(0.0,-8.5,-1.0,1.0);
+    let target = Vec4::new(0.0,0.0,0.0,1.0);
+
+    // World coordinates -> Camera coordinates
+    let view = Mat4::<f32>::look_at_rh(eye, target, Vec4::up());
+    let projection = Mat4::perspective_rh_no(0.35*PI, (image_width as f32)/(image_height as f32), 0.01, 100.0);
+
+    let scale = 10;
     let background = Rgba {r: 0.62, g: 0.62, b: 0.62, a: 1.0};
 
     let mut color = Buffer2d::new([image_width, image_height], background);

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::num::{NonZeroUsize, NonZeroU32};
 
 use vek::{Vec3, Rgba};
 use serde::{Serialize, Deserialize};
+use crate::shader::Camera;
 
 /// A newtype around PathBuf to force the path to be resolved relative to a base directory before
 /// it can be used. Good to prevent something that is pretty easy to do accidentally.
@@ -155,14 +156,7 @@ impl Default for Outline {
 #[serde(untagged)]
 pub enum PresetCamera {
     Perspective(Perspective),
-    Custom {
-        /// The position of the camera (world coordinates)
-        /// Specify as an object: {x = 1.23, y = 4.56, z = 7.89}
-        position: Vec3<f32>,
-        /// The target position to look at (world coordinates)
-        /// Specify as an object: {x = 1.23, y = 4.56, z = 7.89}
-        target: Vec3<f32>,
-    },
+    Custom(Camera),
 }
 
 /// Preset perspective cameras for common angles

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::num::{NonZeroUsize, NonZeroU32};
 
-use vek::{Vec3, Rgba};
+use vek::{Rgba};
 use serde::{Serialize, Deserialize};
 use crate::shader::Camera;
 

--- a/src/shader/camera.rs
+++ b/src/shader/camera.rs
@@ -8,20 +8,20 @@ use crate::config;
 #[serde(default)]
 #[serde(deny_unknown_fields)]
 pub struct Camera {
-    pub(crate) eye: Vec4<f32>,
-    pub(crate) target: Vec4<f32>,
-    pub(crate) fovy: f32,
-    pub(crate) aspect_ratio_x: f32,
-    pub(crate) aspect_ratio_y: f32,
-    pub(crate) near: f32,
-    pub(crate) far: f32,
+     eye: Vec4<f32>,
+     target: Vec4<f32>,
+     fovy: f32,
+     aspect_ratio_x: f32,
+     aspect_ratio_y: f32,
+     near: f32,
+     far: f32,
 }
 
 impl Default for Camera {
     fn default() -> Camera {
         Camera {
-            eye: Vec4::new(0.0,1.0,8.5,1.0),
-            target: Vec4::new(0.0,0.0,0.0,1.0),
+            eye: Vec4{x:0.0, y:1.0, z:8.5, w:1.0},
+            target: Vec4{x:0.0, y:0.0, z:0.0, w:1.0},
             fovy: 0.35*PI,
             aspect_ratio_x: 1.0,
             aspect_ratio_y: 1.0,
@@ -36,8 +36,7 @@ impl From<config::PresetCamera> for Camera {
         use config::PresetCamera::*;
         match cam {
             Perspective(persp) => persp.into(),
-            //TODO(#4): This should be implemented as part of #4.
-            Custom(camera) => camera.into(),
+            Custom(camera) => camera,
         }
     }
 }
@@ -45,16 +44,15 @@ impl From<config::PresetCamera> for Camera {
 impl From<config::Perspective> for Camera {
     fn from(persp: config::Perspective) -> Self {
 
-        // NOTE: PerspectiveLeft means point the camera to the left side of the x axis( negative x values ).
-        // I.e: the camera is actually looking at the right side of the model
+        // NOTE: PerspectiveLeft means point the camera to the left side of the model
         use config::Perspective::*;
-        let mut eye = match persp {
-            PerspectiveFront => Vec4::new(0.0,1.0,8.5,1.0),
-            PerspectiveBack => Vec4::new(0.0,1.0,-8.5,1.0),
-            PerspectiveLeft => Vec4::new(-8.5,1.0,0.0,1.0),
-            PerspectiveRight => Vec4::new(8.5,1.0,0.0,1.0),
-            PerspectiveTop => Vec4::new(0.0,8.5,-1.0,1.0),
-            PerspectiveBottom => Vec4::new(0.0,-8.5,-1.0,1.0),
+        let eye = match persp {
+            PerspectiveFront => Vec4{x:0.0, y:0.0, z:8.5, w:1.0},
+            PerspectiveBack => Vec4{x:0.0, y:0.0, z:-8.5, w:1.0},
+            PerspectiveLeft => Vec4{x:-8.5, y:0.0, z:0.0, w:1.0},
+            PerspectiveRight => Vec4{x:8.5, y:0.0, z:0.0, w:1.0},
+            PerspectiveTop => Vec4{x:0.0, y:8.5, z:-1.0, w:1.0},
+            PerspectiveBottom => Vec4{x:0.0, y:-8.5, z:-1.0, w:1.0},
         };
         Camera {eye, ..Default::default()}
     }

--- a/src/shader/cel.rs
+++ b/src/shader/cel.rs
@@ -45,13 +45,13 @@ impl<'a> Pipeline for CelShader<'a> {
         let v_index = *v_index as usize;
         // Find vertex position
         let v_pos = Vec4::from_point(self.mesh.position(v_index));
+        let v_pos_cam_4 = (self.mvp * v_pos).homogenized();
         // Calculate vertex position in camera space
-        let v_pos_cam = Vec3::from(self.mvp * v_pos).into_array();
+        let mut v_pos_cam = Vec3::from(v_pos_cam_4).into_array();
         // Find vertex normal
         let v_norm = Vec4::from_point(self.mesh.normal(v_index));
         // Transform normals to preserve orthogonality after non-uniform transformations.
-        let v_norm = Vec3::from((self.model_inverse_transpose * v_norm).normalized());
-
+        let v_norm = Vec3::from((self.model_inverse_transpose * v_norm).normalized());    
         (v_pos_cam, v_norm)
     }
 

--- a/src/shader/cel.rs
+++ b/src/shader/cel.rs
@@ -45,13 +45,12 @@ impl<'a> Pipeline for CelShader<'a> {
         let v_index = *v_index as usize;
         // Find vertex position
         let v_pos = Vec4::from_point(self.mesh.position(v_index));
-        let v_pos_cam_4 = (self.mvp * v_pos).homogenized();
         // Calculate vertex position in camera space
-        let mut v_pos_cam = Vec3::from(v_pos_cam_4).into_array();
+        let v_pos_cam = Vec3::from((self.mvp * v_pos).homogenized()).into_array();
         // Find vertex normal
         let v_norm = Vec4::from_point(self.mesh.normal(v_index));
         // Transform normals to preserve orthogonality after non-uniform transformations.
-        let v_norm = Vec3::from((self.model_inverse_transpose * v_norm).normalized());    
+        let v_norm = Vec3::from((self.model_inverse_transpose * v_norm).normalized());
         (v_pos_cam, v_norm)
     }
 

--- a/src/shader/outline.rs
+++ b/src/shader/outline.rs
@@ -39,7 +39,7 @@ impl<'a> Pipeline for OutlineShader<'a> {
         // Find vertex position
         let v_pos = Vec4::from_point(self.mesh.position(v_index));
         // Calculate vertex position in camera space
-        let v_pos_cam = Vec3::from(self.mvp * v_pos);
+        let v_pos_cam = Vec3::from((self.mvp * v_pos).homogenized());
         // Find vertex normal
         let v_norm = Vec4::from_point(self.mesh.normal(v_index));
         // Transform normals to preserve orthogonality after non-uniform transformation


### PR DESCRIPTION
**The following new camera configurations can be enabled:**
- generating different angles of a pose from default values (perspectiveFront,back,left,right,top,bottom)
- generating custom camera configurations from eye and target position vectors, fovy, near and far planes, and aspect ratios

As a result, we no longer need adhoc scaling to fit our given model in the viewing frame. We can simply change the positions of the camera's 'eye' and 'target' vectors as if you were walking up closer to or farther from the model. This was mostly fixed by homogenizing the transformed vertex coordinates in the vertex shader by the 'w' coordinate value.

**Side-effects**
- outlines don't show because they are hidden by the now transformed model
