### PR TITLE
Quick Refactor: New math module

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use vek::{Vec3, Rgba};
+use crate::math::{Vec3, Rgba, Degrees};
 use serde::{Serialize, Deserialize};
 
 /// A newtype around PathBuf to force the path to be resolved relative to a base directory before
@@ -47,7 +47,7 @@ pub struct Spritesheet {
     pub scale: NonZeroU32,
     /// The background color of the spritesheet (default: transparent black)
     #[serde(default = "default_background")]
-    pub background: Rgba<f32>,
+    pub background: Rgba,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -120,7 +120,7 @@ pub struct Pose {
     pub scale: NonZeroU32,
     /// The background color of the generated image (default: transparent black)
     #[serde(default = "default_background")]
-    pub background: Rgba<f32>,
+    pub background: Rgba,
     /// The outline to use when drawing the generated image. (default: no outline)
     #[serde(default)]
     pub outline: Outline,
@@ -154,7 +154,7 @@ pub struct Outline {
     /// (default: 0.0)
     pub thickness: f32,
     /// The color of the outline to draw (default: black)
-    pub color: Rgba<f32>,
+    pub color: Rgba,
 }
 
 impl Default for Outline {
@@ -192,13 +192,13 @@ pub enum Perspective {
 #[serde(default)]
 pub struct Camera {
     /// The position of the camera in world coordinates
-    pub eye: Vec3<f32>,
+    pub eye: Vec3,
     /// The target position that the camera should be looking at
-    pub target: Vec3<f32>,
+    pub target: Vec3,
     /// The aspect ratio of the viewport
     pub aspect_ratio: f32,
     /// Field of view angle in the y-direction - the "opening angle" of the camera in degrees
-    pub fov_y: f32,
+    pub fov_y: Degrees,
     /// Coordinate of the near clipping plane on the camera's local z-axis
     pub near_z: f32,
     /// Coordinate of the far clipping plane on the camera's local z-axis
@@ -213,7 +213,7 @@ impl Default for Camera {
             eye: Vec3 {x: 8.0, y: 8.0, z: 8.0},
             target: Vec3::zero(),
             aspect_ratio: 1.0,
-            fov_y: 40.0,
+            fov_y: Degrees::from_degrees(40.0),
             near_z: 0.1,
             far_z: Some(100.0),
         }
@@ -238,7 +238,7 @@ impl From<Perspective> for Camera {
 }
 
 fn default_scale_factor() -> NonZeroU32 { NonZeroU32::new(1).unwrap() }
-fn default_background() -> Rgba<f32> { Rgba {r: 0.0, g: 0.0, b: 0.0, a: 0.0} }
+fn default_background() -> Rgba { Rgba {r: 0.0, g: 0.0, b: 0.0, a: 0.0} }
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,3 +28,4 @@ pub mod tasks;
 pub mod renderer;
 pub mod query3d;
 pub mod scene;
+pub mod math;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,80 @@
+//! Math-related utilities/constants/type definitions.
+//!
+//! The vek crate that we use to provide math primitives is very generic, but we will always want
+//! to use it with floats. This module exports type aliases that allow us to not have to specify
+//! that we are using "f32" all the time.
+
+use serde::{Serialize, Deserialize};
+
+pub type Vec2 = vek::Vec2<f32>;
+pub type Vec3 = vek::Vec3<f32>;
+pub type Vec4 = vek::Vec4<f32>;
+
+pub type Mat2 = vek::Mat2<f32>;
+pub type Mat3 = vek::Mat3<f32>;
+pub type Mat4 = vek::Mat4<f32>;
+
+pub type Quaternion = vek::Quaternion<f32>;
+
+pub type Rgb = vek::Rgb<f32>;
+pub type Rgba = vek::Rgba<f32>;
+
+pub type FrustumPlanes = vek::FrustumPlanes<f32>;
+
+/// A "newtype" to represent a value with the unit "radians"
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Radians(f32);
+
+impl From<Degrees> for Radians {
+    fn from(value: Degrees) -> Self {
+        Radians::from_radians(value.get_radians())
+    }
+}
+
+impl Radians {
+    pub fn from_degrees(value: f32) -> Self {
+        Radians(value.to_radians())
+    }
+
+    pub fn from_radians(value: f32) -> Self {
+        Radians(value)
+    }
+
+    pub fn get_radians(self) -> f32 {
+        self.0
+    }
+
+    pub fn get_degrees(self) -> f32 {
+        self.0.to_degrees()
+    }
+}
+
+/// A "newtype" to represent a value with the unit "degrees"
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Degrees(f32);
+
+impl From<Radians> for Degrees {
+    fn from(value: Radians) -> Self {
+        Degrees::from_degrees(value.get_degrees())
+    }
+}
+
+impl Degrees {
+    pub fn from_degrees(value: f32) -> Self {
+        Degrees(value)
+    }
+
+    pub fn from_radians(value: f32) -> Self {
+        Degrees(value.to_degrees())
+    }
+
+    pub fn get_radians(self) -> f32 {
+        self.0.to_radians()
+    }
+
+    pub fn get_degrees(self) -> f32 {
+        self.0
+    }
+}

--- a/src/query3d/backend/obj.rs
+++ b/src/query3d/backend/obj.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use vek::Mat4;
+use crate::math::Mat4;
 use rayon::iter::{ParallelIterator, IntoParallelIterator};
 
 use crate::scene::{Mesh, Material};

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -18,7 +18,7 @@ pub use job::*;
 pub use light::*;
 pub use camera::*;
 
-use vek::{Rgba, Mat4, Vec3, Vec4};
+use crate::math::{Rgba, Mat4, Vec3, Vec4};
 use glium::{Surface, framebuffer::SimpleFrameBuffer};
 
 use shader::cel::CelUniforms;
@@ -39,7 +39,7 @@ impl<'a> Renderer<'a> {
     }
 
     /// Clears the screen and resets the depth buffer
-    pub fn clear(&mut self, background: Rgba<f32>) {
+    pub fn clear(&mut self, background: Rgba) {
         self.target.clear_color_and_depth(background.into_tuple(), 1.0);
     }
 
@@ -47,8 +47,8 @@ impl<'a> Renderer<'a> {
     pub fn render(
         &mut self,
         geometry: &ShaderGeometry,
-        view: Mat4<f32>,
-        projection: Mat4<f32>,
+        view: Mat4,
+        projection: Mat4,
         outline: &Outline,
     ) -> Result<(), glium::DrawError> {
         let cel_params = glium::DrawParameters {

--- a/src/renderer/camera.rs
+++ b/src/renderer/camera.rs
@@ -1,9 +1,9 @@
-use vek::Mat4;
+use crate::math::Mat4;
 
 #[derive(Debug, Clone)]
 pub struct Camera {
     /// The view matrix of this camera
-    pub view: Mat4<f32>,
+    pub view: Mat4,
     /// The projection matrix of this camera
-    pub projection: Mat4<f32>,
+    pub projection: Mat4,
 }

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -1,11 +1,11 @@
-use vek::{Vec3, Rgba};
+use crate::math::{Vec3, Rgba};
 
 #[derive(Debug)]
 pub struct DirectionalLight {
     /// The **normalized** direction of the diffuse light being cast on the model
-    pub direction: Vec3<f32>,
+    pub direction: Vec3,
     /// The color of the diffuse light
-    pub color: Rgba<f32>,
+    pub color: Rgba,
     /// The intensity of the diffuse light
     pub intensity: f32,
 }

--- a/src/renderer/rendered_image.rs
+++ b/src/renderer/rendered_image.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
 
-use vek::Rgba;
+use crate::math::Rgba;
 
 use crate::query3d::{GeometryQuery, LightQuery, CameraQuery, File, QueryError, QueryBackend};
 
@@ -13,7 +13,7 @@ pub struct RenderedImage {
     /// The size at which to render the generated image
     pub size: Size,
     /// The background color of the generated image
-    pub background: Rgba<f32>,
+    pub background: Rgba,
     /// The camera perspective from which to render each frame
     pub camera: RenderCamera,
     /// The lights to use to light the rendered scene
@@ -59,7 +59,7 @@ pub struct Outline {
     /// The value must not be negative.
     pub thickness: f32,
     /// The color of the outline to draw
-    pub color: Rgba<f32>,
+    pub color: Rgba,
 }
 
 #[derive(Debug)]

--- a/src/renderer/shader/cel.rs
+++ b/src/renderer/shader/cel.rs
@@ -1,4 +1,4 @@
-use vek::Mat4;
+use crate::math::Mat4;
 use glium::uniforms::{Uniforms, UniformValue};
 
 use crate::scene::Material;
@@ -9,8 +9,8 @@ pub use super::light_uniform::DirectionalLightUniform;
 pub use super::material_uniform::MaterialUniform;
 
 pub struct CelUniforms<'a> {
-    pub mvp: Mat4<f32>,
-    pub model_view_inverse_transpose: Mat4<f32>,
+    pub mvp: Mat4,
+    pub model_view_inverse_transpose: Mat4,
     pub light: &'a DirectionalLight,
     pub ambient_intensity: f32,
     pub material: &'a Material,

--- a/src/renderer/shader/outline.rs
+++ b/src/renderer/shader/outline.rs
@@ -1,10 +1,10 @@
-use vek::{Mat4, Rgba};
+use crate::math::{Mat4, Rgba};
 use glium::uniforms::{Uniforms, UniformValue};
 
 pub struct OutlineUniforms {
-    pub mvp: Mat4<f32>,
+    pub mvp: Mat4,
     pub outline_thickness: f32,
-    pub outline_color: Rgba<f32>,
+    pub outline_color: Rgba,
 }
 
 /// This struct must match the uniforms in the outline shaders

--- a/src/renderer/shader_geometry.rs
+++ b/src/renderer/shader_geometry.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use vek::{Vec3, Mat4};
+use crate::math::{Vec3, Mat4};
 use glium::{
     VertexBuffer,
     IndexBuffer,
@@ -25,18 +25,18 @@ pub enum ShaderGeometryError {
 #[derive(Debug)]
 pub struct ShaderGeometry {
     pub indices: IndexBuffer<u32>,
-    pub positions: VertexBuffer<Vec3<f32>>,
-    pub normals: VertexBuffer<Vec3<f32>>,
+    pub positions: VertexBuffer<Vec3>,
+    pub normals: VertexBuffer<Vec3>,
     pub material: Arc<Material>,
     /// The world transform of this geometry
-    pub model_transform: Mat4<f32>,
+    pub model_transform: Mat4,
 }
 
 impl ShaderGeometry {
     pub fn new(
         display: &Display,
         geo: &Geometry,
-        model_transform: Mat4<f32>,
+        model_transform: Mat4,
     ) -> Result<Self, ShaderGeometryError> {
         const POSITION_ATTR_TYPE: AttributeType = AttributeType::F32F32F32;
         let position_bindings: VertexFormat = Cow::Borrowed(&[
@@ -58,7 +58,7 @@ impl ShaderGeometry {
             indices: IndexBuffer::immutable(display, PrimitiveType::TrianglesList, indices)?,
             // These calls to new_raw are safe assuming that the specified attribute types
             // correspond to the types of the items stored in the `positions` and `normals` fields
-            // of Mesh. This should be the case because `Vec3<f32>` is #[repr(C)] and therefore it
+            // of Mesh. This should be the case because `Vec3` is #[repr(C)] and therefore it
             // should have the same layout as a C struct with three 32-bit floating point values.
             //TODO: Use BufferMode::Immutable here too. glium doesn't currently have a
             // new_raw_immutable method.

--- a/src/scene/camera_type.rs
+++ b/src/scene/camera_type.rs
@@ -1,4 +1,4 @@
-use vek::{Mat4, FrustumPlanes};
+use crate::math::{Mat4, FrustumPlanes, Radians};
 
 #[derive(Debug, Clone)]
 pub enum CameraType {
@@ -6,7 +6,7 @@ pub enum CameraType {
         /// The aspect ratio of the viewport
         aspect_ratio: f32,
         /// Field of view in the y-direction - the "opening angle" of the camera in radians
-        field_of_view_y: f32,
+        field_of_view_y: Radians,
         /// Coordinate of the near clipping plane on the camera's local z-axis
         near_z: f32,
         /// Coordinate of the far clipping plane on the camera's local z-axis
@@ -37,7 +37,7 @@ impl<'a> From<gltf::Camera<'a>> for CameraType {
         match cam.projection() {
             Perspective(persp) => CameraType::Perspective {
                 aspect_ratio: persp.aspect_ratio().unwrap_or(0.0),
-                field_of_view_y: persp.yfov(),
+                field_of_view_y: Radians::from_radians(persp.yfov()),
                 near_z: persp.znear(),
                 far_z: persp.zfar(),
             },
@@ -56,19 +56,19 @@ impl CameraType {
     /// The perspective/orthographic projection matrix of the camera.
     ///
     /// Camera coordinates -> Homogenous coordinates
-    pub fn to_projection(&self) -> Mat4<f32> {
+    pub fn to_projection(&self) -> Mat4 {
         // OpenGL clip planes are -1 to 1, thus we use the _no method
         use CameraType::*;
         match *self {
             Perspective {aspect_ratio, field_of_view_y, near_z, far_z} => match far_z {
                 Some(far_z) => {
-                    Mat4::perspective_rh_no(field_of_view_y, aspect_ratio, near_z, far_z)
+                    Mat4::perspective_rh_no(field_of_view_y.get_radians(), aspect_ratio, near_z, far_z)
                 },
 
                 None => {
                     // Infinite projection matrix
                     // Source: http://www.terathon.com/gdc07_lengyel.pdf
-                    let focal_length = 1.0 / (field_of_view_y / 2.0).tan();
+                    let focal_length = 1.0 / (field_of_view_y.get_radians() / 2.0).tan();
                     Mat4::new(
                         focal_length,   0.0,                            0.0,    0.0,
                         0.0,            focal_length / aspect_ratio,    0.0,    0.0,

--- a/src/scene/geometry.rs
+++ b/src/scene/geometry.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use vek::Vec3;
+use crate::math::Vec3;
 
 use super::Material;
 
@@ -12,9 +12,9 @@ pub struct Geometry {
     /// The indexes that represent the triangles of this geometry
     pub indices: Vec<u32>,
     /// The position of each vertex of the geometry
-    pub positions: Vec<Vec3<f32>>,
+    pub positions: Vec<Vec3>,
     /// The normal of each vertex of the geometry
-    pub normals: Vec<Vec3<f32>>,
+    pub normals: Vec<Vec3>,
     /// The material associated with this geometry
     pub material: Arc<Material>,
 }

--- a/src/scene/material.rs
+++ b/src/scene/material.rs
@@ -1,8 +1,8 @@
-use vek::Rgba;
+use crate::math::Rgba;
 
 #[derive(Debug)]
 pub struct Material {
-    pub diffuse_color: Rgba<f32>,
+    pub diffuse_color: Rgba,
 }
 
 impl Default for Material {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::path::Path;
 use std::num::NonZeroU32;
 
-use vek::{Mat4, Vec3};
+use crate::math::{Mat4, Vec3};
 use interpolation::lerp;
 
 use crate::config;
@@ -186,7 +186,7 @@ fn config_to_camera(cam: config::PresetCamera) -> Camera {
     let config::Camera {eye, target, aspect_ratio, fov_y, near_z, far_z} = cam;
     let cam_type = CameraType::Perspective {
         aspect_ratio,
-        field_of_view_y: fov_y.to_radians(),
+        field_of_view_y: fov_y.into(),
         near_z,
         far_z,
     };


### PR DESCRIPTION
Hello @ProtoArt/core-team!
I am still out sick right now, so I can't work on any substantial features at the moment. Having said that, I thought I'd take this opportunity to do a quick find/replace refactor of some things that have been bothering me for a while.

1. **type aliases for `vek` types**
   vek is a great library and is very generic so you can use it with all kinds of types like `f32`, `f64`, etc. Since we're a graphics application that mostly runs on the GPU, we only tend to use `f32` in our code. That's why I've created a module called `math.rs` that contains type aliases which map things like `Vec3<f32>`, `Vec4<f32>`, and `Mat4<f32>` to just `Vec3`, `Vec4`, and `Mat4`. This will both save us some typing when we're writing code, and reduce a lot of noise when we're reading code. Type aliases are great for removing duplication in types and that's exactly what we're doing here. :)

2. **explicit unit types for degrees and radians**
   This part of the PR is a great example of how you can use types to improve the static correctness of your code and how you can use the interfaces of those types to make reviewing code easier. I've created two structs in `math.rs`, `Degrees` and `Radians` that both just hold a single `f32`. We use each of those types in different places in our code depending on what we expect the unit of a given value to be. This is important because writing code with correct units is actually pretty difficult and managing conversions between units is easy to mess up. By using separate types, we can lean a bit more on the Rust compiler to statically check that we haven't, for example, used degrees where we meant to use radians. There was actually a bug that I caught in #125 that would have been prevented by the compiler had we already made this change.

    Having explicit types like this makes reviewing/auditing the code easier for two main reasons. First, we reduce the amount of unit conversion code that you need to check. As long as the implementation of `Degrees` and `Radians` is correct, you can be sure that any other code using those types will also convert units correctly. The second reason that reviewing becomes easier is because the interface is defined to explicitly spell out when certain units are used. That means that eventually, when you do want the original `f32` value back, you need to explicitly state which unit you want it back in. That allows the reviewer to then check that the units you extracted work for the calculation you're performing.

    This aspect of reviewability is probably better understood with an example. Let's look at this code from `camera_type.rs`:

    ```patch
    @@ -37,7 +37,7 @@ impl<'a> From<gltf::Camera<'a>> for CameraType {
             match cam.projection() {
                 Perspective(persp) => CameraType::Perspective {
                     aspect_ratio: persp.aspect_ratio().unwrap_or(0.0),
    -                field_of_view_y: persp.yfov(),
    +                field_of_view_y: Radians::from_radians(persp.yfov()),
                     near_z: persp.znear(),
                     far_z: persp.zfar(),
                 },
    ```

    The code before was correct, because `persp.yfov()` has a unit of radians [according to its docs](https://docs.rs/gltf/0.14.0/gltf/camera/struct.Perspective.html#method.yfov), but this assumption wasn't made clear in the code. By having `Radians`, and more importantly by having `from_radians`, it's abundantly clear that whoever is reviewing this (or reading this code later) should make sure that the unit is in fact correct.

    Later on in that same file, we have:

    ```patch
    @@ -56,19 +56,19 @@ impl CameraType {
         /// The perspective/orthographic projection matrix of the camera.
         ///
         /// Camera coordinates -> Homogenous coordinates
         pub fn to_projection(&self) -> Mat4 {
             // OpenGL clip planes are -1 to 1, thus we use the _no method
             use CameraType::*;
             match *self {
                 Perspective {aspect_ratio, field_of_view_y, near_z, far_z} => match far_z {
                     Some(far_z) => {
    -                    Mat4::perspective_rh_no(field_of_view_y, aspect_ratio, near_z, far_z)
    +                    Mat4::perspective_rh_no(field_of_view_y.get_radians(), aspect_ratio, near_z, far_z)
                     },
     
                     None => {
                         // Infinite projection matrix
                         // Source: http://www.terathon.com/gdc07_lengyel.pdf
    -                    let focal_length = 1.0 / (field_of_view_y / 2.0).tan();
    +                    let focal_length = 1.0 / (field_of_view_y.get_radians() / 2.0).tan();
                         Mat4::new(
                             focal_length,   0.0,                            0.0,    0.0,
                             0.0,            focal_length / aspect_ratio,    0.0,    0.0,
    ```

    Here, the reviewer of this code knows to check explicitly that `perspective_rh_no` does in fact [take radians](https://docs.rs/vek/0.9.11/vek/mat/repr_c/column_major/mat4/struct.Mat4.html#method.perspective_rh_no). They also explicitly see that we're passing radians into [`tan`](https://doc.rust-lang.org/std/primitive.f32.html#method.tan). This is important because `tan` _only_ takes a value in radians. It's very easy to accidentally pass in degrees if we're just using `f32`.

---

I've created a draft PR for now since this is based on `layout-engine`. When #125 is merged, I'll change this to be based on `master` and we can merge it in.