### PR TITLE
Decomposing a matrix into scale, rotation, and translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,10 +1076,12 @@ dependencies = [
 name = "spritec"
 version = "0.1.0"
 dependencies = [
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glium 0.26.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gltf 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "interpolation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ edition = "2018"
 glium = "0.26.0-alpha6"
 tobj = "0.1"
 vek = { version = "0.9", features = ["serde"] }
+# Keep this version synced with the version from vek
+num-traits = "0.1"
+# Keep this version synced with the version from vek
+approx = "0.1.1"
 image = "0.22"
 gltf = "0.14"
 structopt = "0.2"

--- a/src/math.rs
+++ b/src/math.rs
@@ -4,6 +4,12 @@
 //! to use it with floats. This module exports type aliases that allow us to not have to specify
 //! that we are using "f32" all the time.
 
+mod decompose;
+
+pub mod transforms;
+
+pub use decompose::Decompose;
+
 use serde::{Serialize, Deserialize};
 
 pub type Vec2 = vek::Vec2<f32>;
@@ -20,6 +26,8 @@ pub type Rgb = vek::Rgb<f32>;
 pub type Rgba = vek::Rgba<f32>;
 
 pub type FrustumPlanes = vek::FrustumPlanes<f32>;
+
+pub type Transforms = transforms::Transforms<f32>;
 
 /// A "newtype" to represent a value with the unit "radians"
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]

--- a/src/math/decompose.rs
+++ b/src/math/decompose.rs
@@ -1,0 +1,66 @@
+use std::iter::Sum;
+
+use num_traits::real::Real;
+use vek::{Vec3, Mat3, Mat4, ops::MulAdd};
+
+use super::transforms::Transforms;
+
+/// Extension trait that allows you to decompose a transformation matrix into its scale, rotation,
+/// and translation components.
+pub trait Decompose<T> {
+    /// Decomposes this matrix into its translation, rotation, and scale components.
+    fn decompose(self) -> Transforms<T>;
+}
+
+impl<T: Real + MulAdd<T, T, Output=T> + Sum> Decompose<T> for Mat4<T> {
+    /// Decomposes this matrix into its translation, rotation, and scale components.
+    ///
+    /// The implementation is very basic and does little error detection. Since it
+    /// returns `Transforms`, we do not produce any skew or perspective information (common
+    /// in libraries like glm). That means that you should only expect good results for
+    /// matrices you know are composed of only valid scales, rotations, and translations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use approx::{assert_relative_eq, relative_eq};
+    /// # use vek::{Transform, Mat3, Mat4, Quaternion, Vec3};
+    /// use spritec::math::{Decompose, Transforms};
+    ///
+    /// let (p, rz, s) = (Vec3::unit_x(), 3.0_f32, 5.0_f32);
+    /// let a = Mat4::scaling_3d(s).rotated_z(rz).translated_3d(p);
+    /// let b = Transforms {
+    ///     scale: Vec3::broadcast(s),
+    ///     rotation: Mat3::rotation_z(rz),
+    ///     translation: p,
+    /// };
+    ///
+    /// let a_decomp = a.decompose();
+    /// assert_relative_eq!(a_decomp.scale, b.scale);
+    /// assert_relative_eq!(a_decomp.rotation, b.rotation);
+    /// assert_relative_eq!(a_decomp.translation, b.translation);
+    /// ```
+    fn decompose(self) -> Transforms<T> {
+        // See: https://math.stackexchange.com/a/1463487/161715
+
+        let translation = Vec3 {
+            x: self[(0, 3)],
+            y: self[(1, 3)],
+            z: self[(2, 3)],
+        };
+
+        let sx = Vec3 {x: self[(0, 0)], y: self[(1, 0)], z: self[(2, 0)]}.magnitude();
+        let sy = Vec3 {x: self[(0, 1)], y: self[(1, 1)], z: self[(2, 1)]}.magnitude();
+        let sz = Vec3 {x: self[(0, 2)], y: self[(1, 2)], z: self[(2, 2)]}.magnitude();
+
+        let scale = Vec3 {x: sx, y: sy, z: sz};
+
+        let rotation = Mat3::new(
+            self[(0, 0)] / sx, self[(0, 1)] / sy, self[(0, 2)] / sz,
+            self[(1, 0)] / sx, self[(1, 1)] / sy, self[(1, 2)] / sz,
+            self[(2, 0)] / sx, self[(2, 1)] / sy, self[(2, 2)] / sz,
+        );
+
+        Transforms {scale, rotation, translation}
+    }
+}

--- a/src/math/transforms.rs
+++ b/src/math/transforms.rs
@@ -1,0 +1,33 @@
+use num_traits::{Zero, One};
+use vek::{Vec3, Mat3, Mat4};
+
+/// A container for scale, rotation, and translation
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub struct Transforms<T> {
+    /// The x, y, z scale factors
+    pub scale: Vec3<T>,
+    /// A rotation matrix representing the orientation
+    pub rotation: Mat3<T>,
+    /// A 3D vector representing the position or translation
+    pub translation: Vec3<T>,
+}
+
+impl<T: Zero + One> Default for Transforms<T> {
+    fn default() -> Self {
+        Self {
+            scale: Vec3::zero(),
+            rotation: Mat3::zero(),
+            translation: Vec3::one(),
+        }
+    }
+}
+
+/// Convert to a `Mat4` by multiplying `T*R*S`
+///
+/// Cannot implement generically because Mat4 is an external type
+impl From<Transforms<f32>> for Mat4<f32> {
+    fn from(xform: Transforms<f32>) -> Self {
+        let Transforms {scale, rotation, translation} = xform;
+        Mat4::<f32>::translation_3d(translation) * Mat4::from(rotation) * Mat4::scaling_3d(scale)
+    }
+}


### PR DESCRIPTION
This adds a new trait called `Decompose` which extends `vek::Mat4` so that it can be decomposed into its scale, rotation, and translation components. This initially started as a PR to the vek crate itself, but the implementation burden was too much, so I decided that it would be faster to just add it to our new math module (#126). :tada: 

There is a basic test, so I am fairly confident that this works. Our method for computing the decomposition is very basic though, so it's possible that it is numerically unstable, slow, or otherwise error-prone. I did read through the glm implementation, and this does appear to be just a simplification of that, so we might actually be reasonably okay.

The matrices we're going to be feeding into this are generated by 3D software which means that we have some reasonable expectation of sane inputs. If the inputs aren't reasonable, the function might produce `NaN` values, or otherwise diverge in strange and unpredictable ways.

Despite all of the warnings above, I think it's a reasonable implementation and a good start. This will unblock @JLSJamesShi from being able to implement step 2 of #18. The API has a facility for decomposing a transformation matrix and for recombining it afterwards. This is enough for the basic animations we are out to implement.