### PR TITLE
Lighting Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ num-traits = "0.1"
 # Keep this version synced with the version from vek
 approx = "0.1.1"
 image = "0.22"
-gltf = "0.14"
 structopt = "0.2"
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
@@ -26,6 +25,6 @@ rayon = "1.3"
 thiserror = "1.0"
 interpolation = "0.2"
 
-[profile.dev]
-# Needed to make software rendering fast enough
-opt-level = 3
+[dependencies.gltf]
+version = "0.14"
+features = ["KHR_lights_punctual"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroU32;
 
-use crate::math::{Vec3, Rgba, Degrees};
 use serde::{Serialize, Deserialize};
+
+use crate::math::{Vec3, Rgba, Degrees};
 
 // PathBuf is not imported to avoid its use in this module. Every path in this module should
 // be an UnresolvedPath.

--- a/src/query3d/backend.rs
+++ b/src/query3d/backend.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
-use crate::renderer::{Display, ShaderGeometry, ShaderGeometryError, Camera, DirectionalLight};
+use crate::renderer::{Display, ShaderGeometry, ShaderGeometryError, Camera, Light};
 
 use super::query::{GeometryQuery, CameraQuery, LightQuery};
 
@@ -32,7 +32,7 @@ pub enum QueryError {
 pub trait QueryBackend {
     fn query_geometry(&mut self, query: &GeometryQuery, display: &Display) -> Result<Arc<Vec<Arc<ShaderGeometry>>>, QueryError>;
     fn query_camera(&mut self, query: &CameraQuery) -> Result<Arc<Camera>, QueryError>;
-    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<DirectionalLight>>>, QueryError>;
+    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<Light>>>, QueryError>;
 }
 
 #[derive(Debug, Error)]
@@ -83,7 +83,7 @@ impl QueryBackend for File {
         }
     }
 
-    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<DirectionalLight>>>, QueryError> {
+    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<Light>>>, QueryError> {
         use File::*;
         match self {
             Obj(objs) => objs.query_lights(query),

--- a/src/query3d/backend.rs
+++ b/src/query3d/backend.rs
@@ -22,16 +22,24 @@ pub enum QueryError {
         .name.as_deref().unwrap_or("<unnamed>"))]
     UnknownAnimation {name: Option<String>},
 
-    #[error("Could not find any cameras in model file")]
+    #[error("Could not find any matching geometry in model file")]
+    NoGeometryFound,
+
+    #[error("Could not find any matching cameras in model file")]
     NoCameraFound,
 
-    #[error("Could not find any lights in model file")]
+    #[error("Could not find any matching lights in model file")]
     NoLightsFound,
 }
 
 pub trait QueryBackend {
+    /// Attempts to find geometry matching the given query in this file. Only returns success
+    /// if at least one geometry was found.
     fn query_geometry(&mut self, query: &GeometryQuery, display: &Display) -> Result<Arc<Vec<Arc<ShaderGeometry>>>, QueryError>;
+    /// Attempts to find a camera matching the given query in this file.
     fn query_camera(&mut self, query: &CameraQuery) -> Result<Arc<Camera>, QueryError>;
+    /// Attempts to find lights matching the given query in this file. Only returns success
+    /// if at least one light was found.
     fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<Light>>>, QueryError>;
 }
 

--- a/src/query3d/backend/gltf.rs
+++ b/src/query3d/backend/gltf.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::collections::HashMap;
 
 use crate::scene::{Scene, Traverse, Mesh, Material, CameraType};
-use crate::renderer::{Display, ShaderGeometry, Camera, DirectionalLight};
+use crate::renderer::{Display, ShaderGeometry, Camera, Light};
 use crate::query3d::{GeometryQuery, GeometryFilter, CameraQuery, LightQuery};
 
 use super::{QueryBackend, QueryError};
@@ -96,7 +96,7 @@ impl QueryBackend for GltfFile {
         unimplemented!()
     }
 
-    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<DirectionalLight>>>, QueryError> {
+    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<Light>>>, QueryError> {
         unimplemented!()
     }
 }

--- a/src/query3d/backend/gltf.rs
+++ b/src/query3d/backend/gltf.rs
@@ -90,6 +90,10 @@ impl QueryBackend for GltfFile {
                     }
                 }
 
+                if scene_geo.is_empty() {
+                    return Err(QueryError::NoGeometryFound);
+                }
+
                 let scene_geo = Arc::new(scene_geo);
                 self.scene_shader_geometry.insert(scene_index, scene_geo.clone());
                 Ok(scene_geo)
@@ -124,6 +128,10 @@ impl QueryBackend for GltfFile {
                         let light = Light {data: light.clone(), world_transform};
                         scene_lights.push(Arc::new(light));
                     }
+                }
+
+                if scene_lights.is_empty() {
+                    return Err(QueryError::NoLightsFound);
                 }
 
                 let scene_lights = Arc::new(scene_lights);

--- a/src/query3d/backend/obj.rs
+++ b/src/query3d/backend/obj.rs
@@ -5,7 +5,7 @@ use crate::math::Mat4;
 use rayon::iter::{ParallelIterator, IntoParallelIterator};
 
 use crate::scene::{Mesh, Material};
-use crate::renderer::{Display, ShaderGeometry, Camera, DirectionalLight};
+use crate::renderer::{Display, ShaderGeometry, Camera, Light};
 use crate::query3d::{GeometryQuery, GeometryFilter, AnimationQuery, CameraQuery, LightQuery};
 
 use super::{QueryBackend, QueryError};
@@ -78,7 +78,7 @@ impl QueryBackend for ObjFile {
         }
     }
 
-    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<DirectionalLight>>>, QueryError> {
+    fn query_lights(&mut self, query: &LightQuery) -> Result<Arc<Vec<Arc<Light>>>, QueryError> {
         // OBJ files do not support lights
         // This code still does the work to produce useful errors
         match query {

--- a/src/query3d/backend/obj.rs
+++ b/src/query3d/backend/obj.rs
@@ -56,6 +56,11 @@ impl QueryBackend for ObjFile {
                             ShaderGeometry::new(display, geo, Mat4::identity()).map(Arc::new)
                         })
                         .collect::<Result<Vec<_>, _>>()?);
+
+                    if scene_geometry.is_empty() {
+                        return Err(QueryError::NoGeometryFound);
+                    }
+
                     self.scene_geometry = Some(scene_geometry.clone());
 
                     Ok(scene_geometry)

--- a/src/query3d/backend/obj.rs
+++ b/src/query3d/backend/obj.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::math::Mat4;
 use rayon::iter::{ParallelIterator, IntoParallelIterator};
 
+use crate::math::Mat4;
 use crate::scene::{Mesh, Material};
 use crate::renderer::{Display, ShaderGeometry, Camera, Light};
 use crate::query3d::{GeometryQuery, GeometryFilter, AnimationQuery, CameraQuery, LightQuery};

--- a/src/query3d/query.rs
+++ b/src/query3d/query.rs
@@ -61,3 +61,9 @@ pub enum LightQuery {
         name: Option<String>,
     },
 }
+
+impl LightQuery {
+    pub fn all_in_default_scene() -> Self {
+        LightQuery::Scene {name: None}
+    }
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -18,10 +18,11 @@ pub use job::*;
 pub use light::*;
 pub use camera::*;
 
+use std::sync::Arc;
+
 use glium::{Surface, framebuffer::SimpleFrameBuffer};
 
-use crate::math::{Rgba, Rgb, Mat4, Radians};
-use crate::scene::LightType;
+use crate::math::{Rgba, Rgb, Mat4};
 
 use shader::cel::CelUniforms;
 use shader::outline::OutlineUniforms;
@@ -49,6 +50,8 @@ impl<'a> Renderer<'a> {
     pub fn render(
         &mut self,
         geometry: &ShaderGeometry,
+        lights: &[Arc<Light>],
+        ambient_light: Rgb,
         view: Mat4,
         projection: Mat4,
         outline: &Outline,
@@ -76,30 +79,6 @@ impl<'a> Renderer<'a> {
             backface_culling: glium::draw_parameters::BackfaceCullingMode::CullCounterClockwise,
             ..Default::default()
         };
-
-        //TODO: Once we have support for lights, light info will come from elsewhere
-        let lights = &[
-            Light {
-                data: LightType::Spot {
-                    color: Rgb::green(),
-                    intensity: 1.0,
-                    range: None,
-                    inner_cone_angle: Radians::from_degrees(3.0),
-                    outer_cone_angle: Radians::from_degrees(6.0),
-                }.into(),
-                world_transform: Mat4::model_look_at_rh((-5.0, 20.0, 10.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
-            },
-
-            Light {
-               data: LightType::Point {
-                   color: Rgb::white(),
-                   intensity: 0.5,
-                   range: None,
-               }.into(),
-               world_transform: Mat4::translation_3d((10.0, 5.0, 20.0)),
-            },
-        ];
-        let ambient_light = Rgb::white() * 0.3;
 
         let ShaderGeometry {indices, positions, normals, material, model_transform} = geometry;
         let model_transform = *model_transform;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -18,7 +18,7 @@ pub use job::*;
 pub use light::*;
 pub use camera::*;
 
-use crate::math::{Rgba, Mat4, Vec3, Vec4};
+use crate::math::{Rgba, Rgb, Mat4};
 use glium::{Surface, framebuffer::SimpleFrameBuffer};
 
 use shader::cel::CelUniforms;
@@ -76,22 +76,24 @@ impl<'a> Renderer<'a> {
         };
 
         //TODO: Once we have support for lights, light info will come from elsewhere
-        let light = DirectionalLight {
-            direction: Vec3::from(view * Vec4::up()),
-            color: Rgba::white(),
+        let light = Light::Directional {
+            color: Rgb::white(),
             intensity: 1.0,
         };
+        let light_world_transform = view * Mat4::rotation_x((-90f32).to_radians());
         let ambient_intensity = 0.5;
 
         let ShaderGeometry {indices, positions, normals, material, model_transform} = geometry;
-        let model_view = view * (*model_transform);
-        let mvp = projection * model_view;
-        let model_view_inverse_transpose = model_view.inverted().transposed();
+        let model_transform = *model_transform;
+        let mvp = projection * view * model_transform;
+        let model_inverse_transpose = model_transform.inverted().transposed();
 
         let cel_uniforms = shader::cel::Cel::from(CelUniforms {
             mvp,
-            model_view_inverse_transpose,
+            model_transform,
+            model_inverse_transpose,
             light: &light,
+            light_world_transform,
             ambient_intensity,
             material: &*material,
         });

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -86,7 +86,7 @@ impl<'a> Renderer<'a> {
                     range: None,
                     inner_cone_angle: Radians::from_degrees(3.0),
                     outer_cone_angle: Radians::from_degrees(6.0),
-                },
+                }.into(),
                 world_transform: Mat4::model_look_at_rh((-5.0, 20.0, 10.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
             },
 
@@ -95,7 +95,7 @@ impl<'a> Renderer<'a> {
                    color: Rgb::white(),
                    intensity: 0.5,
                    range: None,
-               },
+               }.into(),
                world_transform: Mat4::translation_3d((10.0, 5.0, 20.0)),
             },
         ];

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -18,8 +18,9 @@ pub use job::*;
 pub use light::*;
 pub use camera::*;
 
-use crate::math::{Rgba, Rgb, Mat4};
 use glium::{Surface, framebuffer::SimpleFrameBuffer};
+
+use crate::math::{Rgba, Rgb, Mat4, Radians};
 
 use shader::cel::CelUniforms;
 use shader::outline::OutlineUniforms;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -21,6 +21,7 @@ pub use camera::*;
 use glium::{Surface, framebuffer::SimpleFrameBuffer};
 
 use crate::math::{Rgba, Rgb, Mat4, Radians};
+use crate::scene::LightType;
 
 use shader::cel::CelUniforms;
 use shader::outline::OutlineUniforms;
@@ -77,12 +78,28 @@ impl<'a> Renderer<'a> {
         };
 
         //TODO: Once we have support for lights, light info will come from elsewhere
-        let light = Light::Directional {
-            color: Rgb::white(),
-            intensity: 1.0,
-        };
-        let light_world_transform = view * Mat4::rotation_x((-90f32).to_radians());
-        let ambient_intensity = 0.5;
+        let lights = &[
+            Light {
+                data: LightType::Spot {
+                    color: Rgb::green(),
+                    intensity: 1.0,
+                    range: None,
+                    inner_cone_angle: Radians::from_degrees(3.0),
+                    outer_cone_angle: Radians::from_degrees(6.0),
+                },
+                world_transform: Mat4::model_look_at_rh((-5.0, 20.0, 10.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
+            },
+
+            Light {
+               data: LightType::Point {
+                   color: Rgb::white(),
+                   intensity: 0.5,
+                   range: None,
+               },
+               world_transform: Mat4::translation_3d((10.0, 5.0, 20.0)),
+            },
+        ];
+        let ambient_light = Rgb::white() * 0.3;
 
         let ShaderGeometry {indices, positions, normals, material, model_transform} = geometry;
         let model_transform = *model_transform;
@@ -93,9 +110,8 @@ impl<'a> Renderer<'a> {
             mvp,
             model_transform,
             model_inverse_transpose,
-            light: &light,
-            light_world_transform,
-            ambient_intensity,
+            lights,
+            ambient_light,
             material: &*material,
         });
 

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -1,61 +1,10 @@
-use crate::math::{Rgb, Radians};
+use crate::scene::LightType;
+use crate::math::Mat4;
 
 #[derive(Debug, Clone)]
-pub enum Light {
-    /// Point lights emit light in all directions from their position in space. Rotation and scale
-    /// are ignored other than for their affect on the position.
-    ///
-    /// The brightness of the light attenuates in a physically correct manner as distance increases
-    /// from the light's position (i.e. brightness goes like the inverse square of the distance).
-    Point {
-        /// The color of the light in linear space
-        color: Rgb,
-
-        /// The intensity of the light in candela (lm/sr)
-        intensity: f32,
-
-        /// Hint defining a distance cutoff at which the light's intensity may be considered to
-        /// have reached zero. Must be non-zero. If None, range is considered to be infinite.
-        range: Option<f32>,
-    },
-
-    /// Directional lights are light sources that act as though they are infinitely far away and
-    /// emit light in the direction of the local -z axis. Position and scale are ignored other than
-    /// for their affect on the orientation of the light.
-    ///
-    /// The light is not attenuated, because it is at an infinite distance away.
-    Directional {
-        /// The color of the light in linear space
-        color: Rgb,
-
-        /// The intensity of the light in lux (lm/m^2)
-        intensity: f32,
-    },
-
-    /// Spot lights emit light in a cone in the direction of the local -z axis. Scale does not
-    /// affect cone shape, and is ignored except for its effect on position and orientation.
-    ///
-    /// The brightness attenuates in a physically correct manner as distance increases from the
-    /// light's position (i.e. brightness goes like the inverse square of the distance).
-    Spot {
-        /// The color of the light in linear space
-        color: Rgb,
-
-        /// The intensity of the light in candela (lm/sr)
-        intensity: f32,
-
-        /// Hint defining a distance cutoff at which the light's intensity may be considered to
-        /// have reached zero. Must be non-zero. If None, range is considered to be infinite.
-        range: Option<f32>,
-
-        /// Angle, in radians, from centre of spotlight where falloff begins. Must be greater than
-        /// or equal to 0 and less than outer_cone_angle.
-        inner_cone_angle: Radians,
-
-        /// Angle, in radians, from centre of spotlight where falloff ends. Must be greater than
-        /// inner_cone_angle and less than or equal to PI / 2.0.
-        ///
-        /// To disable angular attenuation, set this value to PI radians
-        outer_cone_angle: Radians,
-    },
+pub struct Light {
+    /// The type of light and its configuration
+    pub data: LightType,
+    /// The world transform of the light
+    pub world_transform: Mat4,
 }

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -1,11 +1,61 @@
-use crate::math::{Vec3, Rgba};
+use crate::math::Rgb;
 
-#[derive(Debug)]
-pub struct DirectionalLight {
-    /// The **normalized** direction of the diffuse light being cast on the model
-    pub direction: Vec3,
-    /// The color of the diffuse light
-    pub color: Rgba,
-    /// The intensity of the diffuse light
-    pub intensity: f32,
+#[derive(Debug, Clone)]
+pub enum Light {
+    /// Point lights emit light in all directions from their position in space. Rotation and scale
+    /// are ignored other than for their affect on the position.
+    ///
+    /// The brightness of the light attenuates in a physically correct manner as distance increases
+    /// from the light's position (i.e. brightness goes like the inverse square of the distance).
+    Point {
+        /// The color of the light in linear space
+        color: Rgb,
+
+        /// The intensity of the light in candela (lm/sr)
+        intensity: f32,
+
+        /// Hint defining a distance cutoff at which the light's intensity may be considered to
+        /// have reached zero. Must be non-zero. If None, range is considered to be infinite.
+        range: Option<f32>,
+    },
+
+    /// Directional lights are light sources that act as though they are infinitely far away and
+    /// emit light in the direction of the local -z axis. Position and scale are ignored other than
+    /// for their affect on the orientation of the light.
+    ///
+    /// The light is not attenuated, because it is at an infinite distance away.
+    Directional {
+        /// The color of the light in linear space
+        color: Rgb,
+
+        /// The intensity of the light in lux (lm/m^2)
+        intensity: f32,
+    },
+
+    /// Spot lights emit light in a cone in the direction of the local -z axis. Scale does not
+    /// affect cone shape, and is ignored except for its effect on position and orientation.
+    ///
+    /// The brightness attenuates in a physically correct manner as distance increases from the
+    /// light's position (i.e. brightness goes like the inverse square of the distance).
+    Spot {
+        /// The color of the light in linear space
+        color: Rgb,
+
+        /// The intensity of the light in candela (lm/sr)
+        intensity: f32,
+
+        /// Hint defining a distance cutoff at which the light's intensity may be considered to
+        /// have reached zero. Must be non-zero. If None, range is considered to be infinite.
+        range: Option<f32>,
+
+        /// Angle, in radians, from centre of spotlight where falloff begins. Must be greater than
+        /// or equal to 0 and less than outer_cone_angle.
+        inner_cone_angle: f32,
+
+        /// Angle, in radians, from centre of spotlight where falloff ends. Must be greater than
+        /// inner_cone_angle and less than or equal to PI / 2.0.
+        ///
+        /// To disable angular attenuation, set this value to PI radians
+        outer_cone_angle: f32,
+    },
 }

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use crate::scene::LightType;
 use crate::math::Mat4;
 
 #[derive(Debug, Clone)]
 pub struct Light {
     /// The type of light and its configuration
-    pub data: LightType,
+    pub data: Arc<LightType>,
     /// The world transform of the light
     pub world_transform: Mat4,
 }

--- a/src/renderer/light.rs
+++ b/src/renderer/light.rs
@@ -1,4 +1,4 @@
-use crate::math::Rgb;
+use crate::math::{Rgb, Radians};
 
 #[derive(Debug, Clone)]
 pub enum Light {
@@ -50,12 +50,12 @@ pub enum Light {
 
         /// Angle, in radians, from centre of spotlight where falloff begins. Must be greater than
         /// or equal to 0 and less than outer_cone_angle.
-        inner_cone_angle: f32,
+        inner_cone_angle: Radians,
 
         /// Angle, in radians, from centre of spotlight where falloff ends. Must be greater than
         /// inner_cone_angle and less than or equal to PI / 2.0.
         ///
         /// To disable angular attenuation, set this value to PI radians
-        outer_cone_angle: f32,
+        outer_cone_angle: Radians,
     },
 }

--- a/src/renderer/rendered_image.rs
+++ b/src/renderer/rendered_image.rs
@@ -5,7 +5,7 @@ use crate::math::Rgba;
 
 use crate::query3d::{GeometryQuery, LightQuery, CameraQuery, File, QueryError, QueryBackend};
 
-use super::{Camera, DirectionalLight};
+use super::{Camera, Light};
 
 /// An image that will be rendered using the given information
 #[derive(Debug)]
@@ -83,12 +83,12 @@ impl RenderCamera {
 
 #[derive(Debug)]
 pub enum RenderLight {
-    Light(Arc<DirectionalLight>),
+    Light(Arc<Light>),
     Query(FileQuery<LightQuery>),
 }
 
 impl RenderLight {
-    pub fn fetch_lights(&self) -> Result<Arc<Vec<Arc<DirectionalLight>>>, QueryError> {
+    pub fn fetch_lights(&self) -> Result<Arc<Vec<Arc<Light>>>, QueryError> {
         use RenderLight::*;
         match self {
             Light(light) => Ok(Arc::new(vec![light.clone()])),

--- a/src/renderer/rendered_image.rs
+++ b/src/renderer/rendered_image.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
 
-use crate::math::Rgba;
+use crate::math::{Rgb, Rgba};
 
 use crate::query3d::{GeometryQuery, LightQuery, CameraQuery, File, QueryError, QueryBackend};
 
@@ -17,7 +17,9 @@ pub struct RenderedImage {
     /// The camera perspective from which to render each frame
     pub camera: RenderCamera,
     /// The lights to use to light the rendered scene
-    pub lights: Vec<RenderLight>,
+    pub lights: RenderLights,
+    /// The ambient light in the scene
+    pub ambient_light: Rgb,
     /// The geometry to draw in the rendered image
     pub geometry: FileQuery<GeometryQuery>,
     /// The outline to use when drawing the geometry
@@ -82,16 +84,16 @@ impl RenderCamera {
 }
 
 #[derive(Debug)]
-pub enum RenderLight {
-    Light(Arc<Light>),
+pub enum RenderLights {
+    Lights(Arc<Vec<Arc<Light>>>),
     Query(FileQuery<LightQuery>),
 }
 
-impl RenderLight {
+impl RenderLights {
     pub fn fetch_lights(&self) -> Result<Arc<Vec<Arc<Light>>>, QueryError> {
-        use RenderLight::*;
+        use RenderLights::*;
         match self {
-            Light(light) => Ok(Arc::new(vec![light.clone()])),
+            Lights(lights) => Ok(lights.clone()),
             Query(FileQuery {query, file}) => {
                 let mut file = file.lock().expect("bug: file lock was poisoned");
                 file.query_lights(query)

--- a/src/renderer/shader/cel.fs
+++ b/src/renderer/shader/cel.fs
@@ -114,7 +114,7 @@ vec4 apply_light(Light light, vec3 position, vec3 normal) {
         if (light.light_angle_scale != 0.0) {
             // From the reference code provided by glTF:
             // https://github.com/KhronosGroup/glTF/tree/92f59a0dbefe2d54cff38dba103cd70462cc778b/extensions/2.0/Khronos/KHR_lights_punctual#inner-and-outer-cone-angles
-            float cd = dot(light.cone_direction, surface_to_light);
+            float cd = dot(light.cone_direction, -surface_to_light);
             float angular_attenuation = clamp(cd * light.light_angle_scale + light.light_angle_offset, 0.0, 1.0);
             angular_attenuation *= angular_attenuation;
 
@@ -140,17 +140,17 @@ vec4 apply_light(Light light, vec3 position, vec3 normal) {
     // Save alpha for later so we can restore it after changing the color a bunch
     float alpha = color.a;
     if (light_intensity > 0.95) {
-        // Leave the color as-is
-        // e.g. color *= 1.0;
+       // Leave the color as-is
+       // e.g. color *= 1.0;
 
     } else if (light_intensity > 0.5) {
-        color *= 0.7;
+       color *= 0.7;
 
     } else if (light_intensity > 0.05) {
-        color *= 0.35;
+       color *= 0.35;
 
     } else {
-        color *= 0.1;
+       color *= 0.1;
     }
 
     // Gamma correction

--- a/src/renderer/shader/cel.fs
+++ b/src/renderer/shader/cel.fs
@@ -1,12 +1,57 @@
 #version 140
 
-struct DirectionalLight {
-    // The **normalized** direction of the diffuse light being cast on the model
-    vec3 direction;
-    // The color of the diffuse light
-    vec4 color;
-    // The intensity of the diffuse light
-    float intensity;
+// A directional, point or spot light.
+//
+// For directional lights,
+// * position.w = 0.0
+// * range - ignored (suggested: 0.0)
+// * cone_direction - ignored (suggested: vec3(0.0, 0.0, 0.0))
+// * light_angle_scale - ignored (suggested: 0.0)
+// * light_angle_offset - ignored (suggested: 0.0)
+//
+// For point lights,
+// * position.w = 1.0
+// * cone_direction = vec3(0.0, 0.0, 0.0)
+// * light_angle_scale = 0.0
+// * light_angle_offset = 0.0
+//
+// For spot lights,
+// * position.w = 1.0
+struct Light {
+    // If w = 1.0, the position of the light in world coordinates
+    // If w = 0.0, the **normalized** direction that the light travels in
+    vec4 position;
+    // The intensities of the red, green, and blue components of the light
+    // When converting from glTF, this is `light.color * light.intensity`
+    //
+    // All components should be between 0.0 and 1.0
+    vec3 color;
+
+    // Hint defining a distance cutoff at which the light's intensity may be
+    // considered to have reached zero. Supported only for point and spot
+    // lights. Must be non-negative. When 0.0, range is assumed to be infinite.
+    float range;
+
+    // SPOT LIGHT CONE SETTINGS
+    //
+    // Based on reference code provided here:
+    // https://github.com/KhronosGroup/glTF/tree/92f59a0dbefe2d54cff38dba103cd70462cc778b/extensions/2.0/Khronos/KHR_lights_punctual#inner-and-outer-cone-angles
+
+    // the direction from the point of the cone, through the center of the cone
+    vec3 cone_direction;
+    // light_angle_scale = 1.0f / max(0.001f, cos(inner_cone_angle) - cos(outer_cone_angle))
+    float light_angle_scale;
+    // light_angle_offset = -cos(outer_cone_angle) * light_angle_scale
+    float light_angle_offset;
+
+    // Angle, in radians, from centre of spotlight where falloff begins. Must be
+    // greater than or equal to 0 and less than outer_cone_angle.
+    //float inner_cone_angle;
+    // Angle, in radians, from centre of spotlight where falloff ends. Must be
+    // greater than inner_cone_angle and less than or equal to PI / 2.0.
+    //
+    // To disable angular attenuation, set this value to PI radians
+    //float outer_cone_angle;
 };
 
 struct Material {
@@ -14,29 +59,83 @@ struct Material {
 };
 
 // Light parameters
-uniform DirectionalLight light;
+uniform Light light;
 uniform float ambient_intensity;
 
 // Material data
 uniform Material material;
 
-// Both of these vectors are assumed to be normalized
+// This is assumed to be normalized
 in vec3 v_normal;
 in vec3 v_position;
 
-out vec4 color;
+out vec4 frag_color;
 
-// A Cel/Toon shader implementation
-// Initial version based on this article: http://rbwhitaker.wikidot.com/toon-shader
-void main() {
+// https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/a18868cfe652bab4c084c751c80a6cfb55ae0f2f/src/shaders/metallic-roughness.frag#L199-L208
+float range_attenuation(float distance, float range) {
+    if (range <= 0.0) {
+        // range is unlimited
+        return 1.0;
+    }
+
+    return max(min(1.0 - pow(distance / range, 4), 1.0), 0.0) / pow(distance, 2);
+}
+
+// Uses the lighting model to compute the color of a point on a surface.
+//
+// Both position and normal should be in the world coordinate system.
+vec4 apply_light(Light light, vec3 position, vec3 normal) {
+    // The lighting model implemented here is designed around supporting the
+    // glTF punctual lights extension. The calculations performed conform to
+    // that spec. Some features found in other lighting implementations may be
+    // omitted here if they are not supported by glTF.
+    //
+    // glTF punctual lights: https://github.com/KhronosGroup/glTF/tree/92f59a0dbefe2d54cff38dba103cd70462cc778b/extensions/2.0/Khronos/KHR_lights_punctual
+    // General articles about lighting used here:
+    // * https://www.tomdalling.com/blog/modern-opengl/06-diffuse-point-lighting/
+    // * https://www.tomdalling.com/blog/modern-opengl/07-more-lighting-ambient-specular-attenuation-gamma/
+    // * https://www.tomdalling.com/blog/modern-opengl/08-even-more-lighting-directional-lights-spotlights-multiple-lights/
+
+    vec3 surface_to_light;
+    float attenuation = 1.0;
+    if (light.position.w == 0.0) {
+        // Directional light
+
+        surface_to_light = -normalize(light.position.xyz);
+        // No attenuation for directional lights
+        attenuation = 1.0;
+
+    } else {
+        // Point / spot light
+        surface_to_light = normalize(light.position.xyz - position);
+        float distance_to_light = length(surface_to_light);
+        attenuation = range_attenuation(distance_to_light, light.range);
+
+        if (light.light_angle_scale != 0.0) {
+            // From the reference code provided by glTF:
+            // https://github.com/KhronosGroup/glTF/tree/92f59a0dbefe2d54cff38dba103cd70462cc778b/extensions/2.0/Khronos/KHR_lights_punctual#inner-and-outer-cone-angles
+            float cd = dot(light.cone_direction, surface_to_light);
+            float angular_attenuation = clamp(cd * light.light_angle_scale + light.light_angle_offset, 0.0, 1.0);
+            angular_attenuation *= angular_attenuation;
+
+            // https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/a18868cfe652bab4c084c751c80a6cfb55ae0f2f/src/shaders/metallic-roughness.frag#L248
+            attenuation *= angular_attenuation;
+        }
+    }
+
     // Calculate diffuse light amount
     // max() is used to bottom out at zero if the dot product is negative
-    float diffuse_intensity = max(dot(v_normal, light.direction), 0.0);
+    float diffuse_intensity = max(dot(v_normal, surface_to_light), 0.0);
 
     // Calculate what would normally be the final color, including texturing and
     // diffuse lighting
     float light_intensity = ambient_intensity + diffuse_intensity;
-    color = material.diffuse_color * light.intensity;
+    light_intensity *= attenuation;
+    vec4 color = material.diffuse_color * vec4(light.color, 1.0);
+
+    // A Cel/Toon shader implementation
+    // Discretises the color to produce a "toon" effect
+    // Initial version based on this article: http://rbwhitaker.wikidot.com/toon-shader
 
     // Save alpha for later so we can restore it after changing the color a bunch
     float alpha = color.a;
@@ -62,4 +161,10 @@ void main() {
     // Reassign the final alpha because we don't actually want the calculations above to
     // influence this value
     color.a = alpha;
+
+    return color;
+}
+
+void main() {
+    frag_color = apply_light(light, v_position, v_normal);
 }

--- a/src/renderer/shader/cel.rs
+++ b/src/renderer/shader/cel.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use glium::uniforms::{Uniforms, UniformValue};
 
 use crate::math::{Mat4, Rgb};
@@ -17,7 +19,7 @@ pub struct CelUniforms<'a> {
     pub mvp: Mat4,
     pub model_transform: Mat4,
     pub model_inverse_transpose: Mat4,
-    pub lights: &'a [Light],
+    pub lights: &'a [Arc<Light>],
     pub ambient_light: Rgb,
     pub material: &'a Material,
 }
@@ -75,7 +77,8 @@ impl<'a> From<CelUniforms<'a>> for Cel {
             model_transform: UniformValue::Mat4(model_transform.into_col_arrays()),
             model_inverse_transpose: UniformValue::Mat4(model_inverse_transpose.into_col_arrays()),
             num_lights: UniformValue::SignedInt(lights.len() as i32),
-            lights: lights.iter().map(|Light {data, world_transform}| {
+            lights: lights.iter().map(|light| {
+                let Light {data, world_transform} = &**light;
                 LightUniform::new(data, *world_transform)
             }).collect(),
             ambient_light: UniformValue::Vec3(ambient_light.into_array()),

--- a/src/renderer/shader/cel.rs
+++ b/src/renderer/shader/cel.rs
@@ -1,6 +1,6 @@
 use glium::uniforms::{Uniforms, UniformValue};
 
-use crate::math::Mat4;
+use crate::math::{Mat4, Rgb};
 use crate::scene::Material;
 use crate::renderer::Light;
 
@@ -8,13 +8,17 @@ use super::nested_uniforms::NestedUniforms;
 pub use super::light_uniform::LightUniform;
 pub use super::material_uniform::MaterialUniform;
 
+/// The maximum supported number of lights
+///
+/// This value must match the corresponding value in the cel shaders
+const MAX_LIGHTS: usize = 10;
+
 pub struct CelUniforms<'a> {
     pub mvp: Mat4,
     pub model_transform: Mat4,
     pub model_inverse_transpose: Mat4,
-    pub light: &'a Light,
-    pub light_world_transform: Mat4,
-    pub ambient_intensity: f32,
+    pub lights: &'a [Light],
+    pub ambient_light: Rgb,
     pub material: &'a Material,
 }
 
@@ -23,8 +27,9 @@ pub struct Cel {
     mvp: UniformValue<'static>,
     model_transform: UniformValue<'static>,
     model_inverse_transpose: UniformValue<'static>,
-    light: LightUniform,
-    ambient_intensity: UniformValue<'static>,
+    num_lights: UniformValue<'static>,
+    lights: Vec<LightUniform>,
+    ambient_light: UniformValue<'static>,
     material: MaterialUniform,
 }
 
@@ -34,16 +39,20 @@ impl Uniforms for Cel {
             mvp,
             model_transform,
             model_inverse_transpose,
-            light,
-            ambient_intensity,
+            num_lights,
+            lights,
+            ambient_light,
             material,
         } = self;
 
         visit("mvp", *mvp);
         visit("model_transform", *model_transform);
         visit("model_inverse_transpose", *model_inverse_transpose);
-        light.visit_nested("light", &mut visit);
-        visit("ambient_intensity", *ambient_intensity);
+        visit("num_lights", *num_lights);
+        for (i, light) in lights.iter().enumerate() {
+            light.visit_nested_index("lights", i, &mut visit);
+        }
+        visit("ambient_light", *ambient_light);
         material.visit_nested("material", &mut visit);
     }
 }
@@ -54,18 +63,22 @@ impl<'a> From<CelUniforms<'a>> for Cel {
             mvp,
             model_transform,
             model_inverse_transpose,
-            light,
-            light_world_transform,
-            ambient_intensity,
+            lights,
+            ambient_light,
             material,
         } = cel_uniforms;
+
+        assert!(lights.len() <= MAX_LIGHTS, "Only up to {} lights can be rendered at any given time", MAX_LIGHTS);
 
         Self {
             mvp: UniformValue::Mat4(mvp.into_col_arrays()),
             model_transform: UniformValue::Mat4(model_transform.into_col_arrays()),
             model_inverse_transpose: UniformValue::Mat4(model_inverse_transpose.into_col_arrays()),
-            light: LightUniform::new(light, light_world_transform),
-            ambient_intensity: UniformValue::Float(ambient_intensity),
+            num_lights: UniformValue::SignedInt(lights.len() as i32),
+            lights: lights.iter().map(|Light {data, world_transform}| {
+                LightUniform::new(data, *world_transform)
+            }).collect(),
+            ambient_light: UniformValue::Vec3(ambient_light.into_array()),
             material: MaterialUniform::new(material),
         }
     }

--- a/src/renderer/shader/cel.rs
+++ b/src/renderer/shader/cel.rs
@@ -2,16 +2,18 @@ use crate::math::Mat4;
 use glium::uniforms::{Uniforms, UniformValue};
 
 use crate::scene::Material;
-use crate::renderer::DirectionalLight;
+use crate::renderer::Light;
 
 use super::nested_uniforms::NestedUniforms;
-pub use super::light_uniform::DirectionalLightUniform;
+pub use super::light_uniform::LightUniform;
 pub use super::material_uniform::MaterialUniform;
 
 pub struct CelUniforms<'a> {
     pub mvp: Mat4,
-    pub model_view_inverse_transpose: Mat4,
-    pub light: &'a DirectionalLight,
+    pub model_transform: Mat4,
+    pub model_inverse_transpose: Mat4,
+    pub light: &'a Light,
+    pub light_world_transform: Mat4,
     pub ambient_intensity: f32,
     pub material: &'a Material,
 }
@@ -19,18 +21,27 @@ pub struct CelUniforms<'a> {
 /// This struct must match the uniforms in the cel shaders
 pub struct Cel {
     mvp: UniformValue<'static>,
-    model_view_inverse_transpose: UniformValue<'static>,
-    light: DirectionalLightUniform,
+    model_transform: UniformValue<'static>,
+    model_inverse_transpose: UniformValue<'static>,
+    light: LightUniform,
     ambient_intensity: UniformValue<'static>,
     material: MaterialUniform,
 }
 
 impl Uniforms for Cel {
     fn visit_values<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, mut visit: F) {
-        let Self {mvp, model_view_inverse_transpose, light, ambient_intensity, material} = self;
+        let Self {
+            mvp,
+            model_transform,
+            model_inverse_transpose,
+            light,
+            ambient_intensity,
+            material,
+        } = self;
 
         visit("mvp", *mvp);
-        visit("model_view_inverse_transpose", *model_view_inverse_transpose);
+        visit("model_transform", *model_transform);
+        visit("model_inverse_transpose", *model_inverse_transpose);
         light.visit_nested("light", &mut visit);
         visit("ambient_intensity", *ambient_intensity);
         material.visit_nested("material", &mut visit);
@@ -39,12 +50,21 @@ impl Uniforms for Cel {
 
 impl<'a> From<CelUniforms<'a>> for Cel {
     fn from(cel_uniforms: CelUniforms<'a>) -> Self {
-        let CelUniforms {mvp, model_view_inverse_transpose, light, ambient_intensity, material} = cel_uniforms;
+        let CelUniforms {
+            mvp,
+            model_transform,
+            model_inverse_transpose,
+            light,
+            light_world_transform,
+            ambient_intensity,
+            material,
+        } = cel_uniforms;
 
         Self {
             mvp: UniformValue::Mat4(mvp.into_col_arrays()),
-            model_view_inverse_transpose: UniformValue::Mat4(model_view_inverse_transpose.into_col_arrays()),
-            light: DirectionalLightUniform::new(light),
+            model_transform: UniformValue::Mat4(model_transform.into_col_arrays()),
+            model_inverse_transpose: UniformValue::Mat4(model_inverse_transpose.into_col_arrays()),
+            light: LightUniform::new(light, light_world_transform),
             ambient_intensity: UniformValue::Float(ambient_intensity),
             material: MaterialUniform::new(material),
         }

--- a/src/renderer/shader/cel.rs
+++ b/src/renderer/shader/cel.rs
@@ -1,6 +1,6 @@
-use crate::math::Mat4;
 use glium::uniforms::{Uniforms, UniformValue};
 
+use crate::math::Mat4;
 use crate::scene::Material;
 use crate::renderer::Light;
 

--- a/src/renderer/shader/cel.vs
+++ b/src/renderer/shader/cel.vs
@@ -2,18 +2,25 @@
 
 // The Model View Projection matrix
 uniform mat4 mvp;
-// The transpose of the inverse of the matrix view * model, used for
+// The model matrix
+uniform mat4 model_transform;
+// The transpose of the inverse of the model matrix, used for
 // transforming the vertex's normal
-uniform mat4 model_view_inverse_transpose;
+uniform mat4 model_inverse_transpose;
 
 in vec3 position;
 in vec3 normal;
 
+// The normal, in the world coordinate system
 out vec3 v_normal;
+// The position, in the world coordinate system
+out vec3 v_position;
 
 void main() {
     // Transform normals to preserve orthogonality after non-uniform transformations.
-    v_normal = mat3(model_view_inverse_transpose) * normal;
+    v_normal = mat3(model_inverse_transpose) * normal;
+    v_position = vec3(model_transform * vec4(position, 1.0));
+
     // Transforms the position to screen space
     gl_Position = mvp * vec4(position, 1.0);
 }

--- a/src/renderer/shader/light_uniform.rs
+++ b/src/renderer/shader/light_uniform.rs
@@ -1,30 +1,77 @@
 use glium::uniforms::{Uniforms, UniformValue};
 
-use crate::renderer::DirectionalLight;
+use crate::math::{Mat4, Vec3, Decompose, Transforms};
+use crate::renderer::Light;
 
-/// This struct must match the `DirectionalLight` struct in our shaders
-pub struct DirectionalLightUniform {
-    direction: UniformValue<'static>,
+/// This struct must match the `Light` struct in our shaders
+pub struct LightUniform {
+    position: UniformValue<'static>,
     color: UniformValue<'static>,
-    intensity: UniformValue<'static>,
+    range: UniformValue<'static>,
+    cone_direction: UniformValue<'static>,
+    light_angle_scale: UniformValue<'static>,
+    light_angle_offset: UniformValue<'static>,
 }
 
-impl Uniforms for DirectionalLightUniform {
+impl Uniforms for LightUniform {
     fn visit_values<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, mut visit: F) {
-        let &Self {direction, color, intensity} = self;
-        visit("direction", direction);
+        let &Self {
+            position,
+            color,
+            range,
+            cone_direction,
+            light_angle_scale,
+            light_angle_offset,
+        } = self;
+
+        visit("position", position);
         visit("color", color);
-        visit("intensity", intensity);
+        visit("range", range);
+        visit("cone_direction", cone_direction);
+        visit("light_angle_scale", light_angle_scale);
+        visit("light_angle_offset", light_angle_offset);
     }
 }
 
-impl DirectionalLightUniform {
-    pub fn new(light: &DirectionalLight) -> Self {
-        let DirectionalLight {direction, color, intensity} = light;
-        Self {
-            direction: UniformValue::Vec3(direction.into_array()),
-            color: UniformValue::Vec4(color.into_array()),
-            intensity: UniformValue::Float(*intensity),
+impl LightUniform {
+    pub fn new(light: &Light, world_transform: Mat4) -> Self {
+        // scale is ignored by all the different light types
+        let Transforms {scale: _, rotation, translation: pos} = world_transform.decompose();
+        let direction = rotation * Vec3 {x: 0.0, y: 0.0, z: -1.0};
+
+        use Light::*;
+        match light {
+            Point {color, intensity, range} => Self {
+                position: UniformValue::Vec4([pos.x, pos.y, pos.z, 1.0]),
+                color: UniformValue::Vec3((color * intensity).into_array()),
+                range: UniformValue::Float(range.unwrap_or(0.0)),
+                cone_direction: UniformValue::Vec3([0.0; 3]),
+                light_angle_scale: UniformValue::Float(0.0),
+                light_angle_offset: UniformValue::Float(0.0),
+            },
+
+            Directional {color, intensity} => Self {
+                position: UniformValue::Vec4([direction.x, direction.y, direction.z, 0.0]),
+                color: UniformValue::Vec3((color * intensity).into_array()),
+                range: UniformValue::Float(0.0),
+                cone_direction: UniformValue::Vec3([0.0; 3]),
+                light_angle_scale: UniformValue::Float(0.0),
+                light_angle_offset: UniformValue::Float(0.0),
+            },
+
+            Spot {color, intensity, range, inner_cone_angle, outer_cone_angle} => {
+                let light_angle_scale = 1.0 / 0.001f32.max(inner_cone_angle.cos() - outer_cone_angle.cos());
+                let light_angle_offset = -outer_cone_angle.cos() * light_angle_scale;
+
+                Self {
+                    position: UniformValue::Vec4([pos.x, pos.y, pos.z, 1.0]),
+                    color: UniformValue::Vec3((color * intensity).into_array()),
+                    range: UniformValue::Float(range.unwrap_or(0.0)),
+                    cone_direction: UniformValue::Vec3([direction.x, direction.y, direction.z]),
+                    light_angle_scale: UniformValue::Float(light_angle_scale),
+                    light_angle_offset: UniformValue::Float(light_angle_offset),
+                }
+            },
         }
     }
 }

--- a/src/renderer/shader/light_uniform.rs
+++ b/src/renderer/shader/light_uniform.rs
@@ -60,6 +60,10 @@ impl LightUniform {
             },
 
             Spot {color, intensity, range, inner_cone_angle, outer_cone_angle} => {
+                // cos() expects a value in radians
+                let inner_cone_angle = inner_cone_angle.get_radians();
+                let outer_cone_angle = outer_cone_angle.get_radians();
+
                 let light_angle_scale = 1.0 / 0.001f32.max(inner_cone_angle.cos() - outer_cone_angle.cos());
                 let light_angle_offset = -outer_cone_angle.cos() * light_angle_scale;
 

--- a/src/renderer/shader/light_uniform.rs
+++ b/src/renderer/shader/light_uniform.rs
@@ -1,7 +1,7 @@
 use glium::uniforms::{Uniforms, UniformValue};
 
 use crate::math::{Mat4, Vec3, Decompose, Transforms};
-use crate::renderer::Light;
+use crate::scene::LightType;
 
 /// This struct must match the `Light` struct in our shaders
 pub struct LightUniform {
@@ -34,12 +34,12 @@ impl Uniforms for LightUniform {
 }
 
 impl LightUniform {
-    pub fn new(light: &Light, world_transform: Mat4) -> Self {
+    pub fn new(light: &LightType, world_transform: Mat4) -> Self {
         // scale is ignored by all the different light types
         let Transforms {scale: _, rotation, translation: pos} = world_transform.decompose();
         let direction = rotation * Vec3 {x: 0.0, y: 0.0, z: -1.0};
 
-        use Light::*;
+        use LightType::*;
         match light {
             Point {color, intensity, range} => Self {
                 position: UniformValue::Vec4([pos.x, pos.y, pos.z, 1.0]),

--- a/src/renderer/shader/nested_uniforms.rs
+++ b/src/renderer/shader/nested_uniforms.rs
@@ -2,9 +2,10 @@ use glium::uniforms::{Uniforms, UniformValue};
 
 /// Nests a set of uniforms under a prefix followed by '.'
 ///
-/// Used to create normals with names like `light.color`
+/// Used to create normals with names like `light.color` or `lights[1].color`
 pub trait NestedUniforms: Uniforms {
     fn visit_nested<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, prefix: &str, visit: F);
+    fn visit_nested_index<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, prefix: &str, index: usize, visit: F);
 }
 
 impl<T: Uniforms> NestedUniforms for T {
@@ -15,6 +16,18 @@ impl<T: Uniforms> NestedUniforms for T {
     ) {
         self.visit_values(|name, value| {
             let name = format!("{}.{}", prefix, name);
+            visit(&name, value);
+        });
+    }
+
+    fn visit_nested_index<'a, F: FnMut(&str, UniformValue<'a>)>(
+        &'a self,
+        prefix: &str,
+        index: usize,
+        mut visit: F,
+    ) {
+        self.visit_values(|name, value| {
+            let name = format!("{}[{}].{}", prefix, index, name);
             visit(&name, value);
         });
     }

--- a/src/renderer/shader/nested_uniforms.rs
+++ b/src/renderer/shader/nested_uniforms.rs
@@ -24,11 +24,9 @@ impl<T: Uniforms> NestedUniforms for T {
         &'a self,
         prefix: &str,
         index: usize,
-        mut visit: F,
+        visit: F,
     ) {
-        self.visit_values(|name, value| {
-            let name = format!("{}[{}].{}", prefix, index, name);
-            visit(&name, value);
-        });
+        let prefix_index = format!("{}[{}]", prefix, index);
+        self.visit_nested(&prefix_index, visit);
     }
 }

--- a/src/renderer/shader/outline.rs
+++ b/src/renderer/shader/outline.rs
@@ -1,5 +1,6 @@
-use crate::math::{Mat4, Rgba};
 use glium::uniforms::{Uniforms, UniformValue};
+
+use crate::math::{Mat4, Rgba};
 
 pub struct OutlineUniforms {
     pub mvp: Mat4,

--- a/src/renderer/shader_geometry.rs
+++ b/src/renderer/shader_geometry.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use crate::math::{Vec3, Mat4};
 use glium::{
     VertexBuffer,
     IndexBuffer,
@@ -11,6 +10,7 @@ use glium::{
 };
 use thiserror::Error;
 
+use crate::math::{Vec3, Mat4};
 use crate::scene::{Geometry, Material};
 use crate::renderer::Display;
 

--- a/src/renderer/thread_render_context.rs
+++ b/src/renderer/thread_render_context.rs
@@ -253,9 +253,10 @@ impl ThreadRenderContext {
     }
 
     fn draw_render(&mut self, image: RenderedImage) -> Result<RgbaImage, DrawLayoutError> {
-        let RenderedImage {size, background, camera, lights, geometry, outline} = image;
+        let RenderedImage {size, background, camera, lights, ambient_light, geometry, outline} = image;
         let FileQuery {query, file} = geometry;
         let Camera {view, projection} = *camera.fetch_camera()?;
+        let lights = lights.fetch_lights()?;
 
         let (render_id, mut renderer) = self.begin_render(size)?;
         renderer.clear(background);
@@ -263,7 +264,7 @@ impl ThreadRenderContext {
         let mut file = file.lock().expect("bug: file lock was poisoned");
         let geos = file.query_geometry(&query, renderer.display())?;
         for geo in &*geos {
-            renderer.render(&*geo, view, projection, &outline)?;
+            renderer.render(&*geo, &lights, ambient_light, view, projection, &outline)?;
         }
 
         let image = self.finish_render(render_id)?;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -28,11 +28,12 @@ impl Scene {
         scene: gltf::Scene,
         meshes: &[Arc<Mesh>],
         cameras: &[Arc<CameraType>],
+        lights: &[Arc<LightType>],
     ) -> Self {
         Self {
             name: Some(scene.name().unwrap_or("").to_string()),
             roots: scene.nodes()
-                .map(|node| Arc::new(Node::from_gltf(node, meshes, cameras)))
+                .map(|node| Arc::new(Node::from_gltf(node, meshes, cameras, lights)))
                 .collect(),
         }
     }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -3,12 +3,14 @@ mod geometry;
 mod material;
 mod node;
 mod camera_type;
+mod light_type;
 
 pub use mesh::*;
 pub use geometry::*;
 pub use material::*;
 pub use node::*;
 pub use camera_type::*;
+pub use light_type::*;
 
 use std::sync::Arc;
 

--- a/src/scene/light_type.rs
+++ b/src/scene/light_type.rs
@@ -59,3 +59,33 @@ pub enum LightType {
         outer_cone_angle: Radians,
     },
 }
+
+impl<'a> From<gltf::khr_lights_punctual::Light<'a>> for LightType {
+    fn from(light: gltf::khr_lights_punctual::Light<'a>) -> Self {
+        let color = Rgb::from(light.color());
+        let intensity = light.intensity();
+        let range = light.range();
+
+        use gltf::khr_lights_punctual::Kind::*;
+        match light.kind() {
+            Point => LightType::Point {
+                color,
+                intensity,
+                range,
+            },
+
+            Directional => LightType::Directional {
+                color,
+                intensity,
+            },
+
+            Spot {inner_cone_angle, outer_cone_angle} => LightType::Spot {
+                color,
+                intensity,
+                range,
+                inner_cone_angle: Radians::from_radians(inner_cone_angle),
+                outer_cone_angle: Radians::from_radians(outer_cone_angle),
+            },
+        }
+    }
+}

--- a/src/scene/light_type.rs
+++ b/src/scene/light_type.rs
@@ -1,0 +1,61 @@
+use crate::math::{Rgb, Radians};
+
+#[derive(Debug, Clone)]
+pub enum LightType {
+    /// Point lights emit light in all directions from their position in space. Rotation and scale
+    /// are ignored other than for their affect on the position.
+    ///
+    /// The brightness of the light attenuates in a physically correct manner as distance increases
+    /// from the light's position (i.e. brightness goes like the inverse square of the distance).
+    Point {
+        /// The color of the light in linear space
+        color: Rgb,
+
+        /// The intensity of the light in candela (lm/sr)
+        intensity: f32,
+
+        /// Hint defining a distance cutoff at which the light's intensity may be considered to
+        /// have reached zero. Must be non-zero. If None, range is considered to be infinite.
+        range: Option<f32>,
+    },
+
+    /// Directional lights are light sources that act as though they are infinitely far away and
+    /// emit light in the direction of the local -z axis. Position and scale are ignored other than
+    /// for their affect on the orientation of the light.
+    ///
+    /// The light is not attenuated, because it is at an infinite distance away.
+    Directional {
+        /// The color of the light in linear space
+        color: Rgb,
+
+        /// The intensity of the light in lux (lm/m^2)
+        intensity: f32,
+    },
+
+    /// Spot lights emit light in a cone in the direction of the local -z axis. Scale does not
+    /// affect cone shape, and is ignored except for its effect on position and orientation.
+    ///
+    /// The brightness attenuates in a physically correct manner as distance increases from the
+    /// light's position (i.e. brightness goes like the inverse square of the distance).
+    Spot {
+        /// The color of the light in linear space
+        color: Rgb,
+
+        /// The intensity of the light in candela (lm/sr)
+        intensity: f32,
+
+        /// Hint defining a distance cutoff at which the light's intensity may be considered to
+        /// have reached zero. Must be non-zero. If None, range is considered to be infinite.
+        range: Option<f32>,
+
+        /// Angle, in radians, from centre of spotlight where falloff begins. Must be greater than
+        /// or equal to 0 and less than outer_cone_angle.
+        inner_cone_angle: Radians,
+
+        /// Angle, in radians, from centre of spotlight where falloff ends. Must be greater than
+        /// inner_cone_angle and less than or equal to PI / 2.0.
+        ///
+        /// To disable angular attenuation, set this value to PI radians
+        outer_cone_angle: Radians,
+    },
+}

--- a/src/scene/light_type.rs
+++ b/src/scene/light_type.rs
@@ -63,7 +63,10 @@ pub enum LightType {
 impl<'a> From<gltf::khr_lights_punctual::Light<'a>> for LightType {
     fn from(light: gltf::khr_lights_punctual::Light<'a>) -> Self {
         let color = Rgb::from(light.color());
-        let intensity = light.intensity();
+        // HACK: The glTF exporter for Blender has a bug where it exports the light intensity in
+        //   the wrong units. This works around that issue.
+        // See: https://github.com/KhronosGroup/glTF-Blender-IO/issues/564
+        let intensity = light.intensity() / 1000.0;
         let range = light.range();
 
         use gltf::khr_lights_punctual::Kind::*;

--- a/src/scene/node.rs
+++ b/src/scene/node.rs
@@ -39,7 +39,6 @@ impl Node {
         cameras: &[Arc<CameraType>],
         lights: &[Arc<LightType>],
     ) -> Self {
-        //TODO: Add lighting support by calling node.light() in a third field of this tuple
         let data = match (node.mesh(), node.camera(), node.light()) {
             (None, None, None) => {
                 None


### PR DESCRIPTION
This PR fixes #28 and fixes #118. I've implemented all of the glTF light types including point, directional, and spot lights. I have also added proper support for ambient light. Not only do we support 1 light, we actually support up to 10 lights! That should be plenty for the timebeing. If we want to add more, we should probably switch to a more sophisticated method using multiple passes or something (as outlined in the "Deferred Rendering" section of [this article](https://www.tomdalling.com/blog/modern-opengl/08-even-more-lighting-directional-lights-spotlights-multiple-lights/)).

This PR also adds the ability to query lights from a glTF file. The only light query supported right now is for all the lights in a scene.

## Examples

<img src="https://user-images.githubusercontent.com/530939/72666919-8088d800-39e4-11ea-88eb-baebb1352be6.png" width="128">

This is bigboi with a single spot light and very low ambient light.

<img src="https://user-images.githubusercontent.com/530939/72666952-cc3b8180-39e4-11ea-911e-e96577f164c1.png" width="128">

This is bigboi with a directional light coming down at about a 60&deg; angle.

<img src="https://user-images.githubusercontent.com/530939/72666907-69e28100-39e4-11ea-8bfe-6adfd9a479e0.png" width="128">

This is bigboi with a green spotlight casting down on the left side of the image, and a white point light casting on the middle right
