### PR TITLE
Support for loading glTF cameras

### DIFF
--- a/src/query3d/query.rs
+++ b/src/query3d/query.rs
@@ -53,6 +53,12 @@ pub enum CameraQuery {
     },
 }
 
+impl CameraQuery {
+    pub fn first_in_default_scene() -> Self {
+        CameraQuery::FirstInScene {name: None}
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum LightQuery {
     /// Returns all the lights in the given scene

--- a/src/scene/camera_type.rs
+++ b/src/scene/camera_type.rs
@@ -36,7 +36,7 @@ impl<'a> From<gltf::Camera<'a>> for CameraType {
         use gltf::camera::Projection::*;
         match cam.projection() {
             Perspective(persp) => CameraType::Perspective {
-                aspect_ratio: persp.aspect_ratio().unwrap_or(0.0),
+                aspect_ratio: persp.aspect_ratio().unwrap_or(1.0),
                 field_of_view_y: Radians::from_radians(persp.yfov()),
                 near_z: persp.znear(),
                 far_z: persp.zfar(),

--- a/src/scene/node.rs
+++ b/src/scene/node.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::collections::VecDeque;
 
-use crate::math::{Mat4, Vec3, Quaternion};
+use crate::math::{Mat4, Quaternion};
 
 use super::{Mesh, CameraType, LightType};
 
@@ -25,14 +25,6 @@ pub struct Node {
 }
 
 impl Node {
-    pub fn camera(eye: Vec3, target: Vec3, camera: Arc<CameraType>) -> Self {
-        Self {
-            data: Some(NodeData::Camera(camera)),
-            transform: Mat4::model_look_at_rh(eye, target, Vec3::up()),
-            children: Vec::new(),
-        }
-    }
-
     pub fn from_gltf(
         node: gltf::Node,
         meshes: &[Arc<Mesh>],
@@ -95,6 +87,13 @@ impl Node {
     pub fn mesh(&self) -> Option<&Arc<Mesh>> {
         match &self.data {
             Some(NodeData::Mesh(mesh)) => Some(mesh),
+            _ => None,
+        }
+    }
+
+    pub fn camera(&self) -> Option<&Arc<CameraType>> {
+        match &self.data {
+            Some(NodeData::Camera(cam)) => Some(cam),
             _ => None,
         }
     }


### PR DESCRIPTION
Fixes #30. 

Most of the work for this PR was already done in #125. The only piece remaining was implementing the `query_camera` method (and fixing some bugs).

Much like #141, this leaves adding something to the TOML config for #140. 

This PR builds on #141 and should be merged after that PR is merged. Creating a [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) for now until that is done.

## Example

![spritesheet0](https://user-images.githubusercontent.com/530939/72667456-107d5080-39ea-11ea-8500-e1adf56246ae.png)

This is a spritesheet using glTF models that is rendered using the first camera in that scene. We don't support glTF animations/skinning yet, so all the models are in the same pose.