### PR TITLE
only trigger CI builds on master branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,6 @@
 # https://aka.ms/yaml
+trigger:
+- master
 
 strategy:
   matrix:


### PR DESCRIPTION
Since our workflow is that everything gets merged to master, we shouldn't be triggering builds for individual commits on our own branches.

This doesn't affect PRs, PR builds will still continue to run to make sure that the PR passes (and when it merges into master it'll run again)