### PR TITLE
Storage and application of GLTF animation data

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use serde::{Serialize, Deserialize};
 
-use crate::math::{Vec3, Rgba, Degrees};
+use crate::math::{Vec3, Rgba, Degrees, Milliseconds};
 
 // PathBuf is not imported to avoid its use in this module. Every path in this module should
 // be an UnresolvedPath.
@@ -124,10 +124,10 @@ pub enum AnimationFrames {
         animation: Option<String>,
         /// The "global" animation time in ms at which to start the animation (default: 0.0)
         #[serde(default)]
-        start_time: f32,
+        start_time: Milliseconds,
         /// The "global" animation time in ms at which to end the animation (default: time of the
         /// last keyframe in the animation)
-        end_time: Option<f32>,
+        end_time: Option<Milliseconds>,
         /// The number of steps to take between the start and end time.
         ///
         /// This is the number of frames that will be drawn in the spritesheet.
@@ -187,7 +187,7 @@ pub enum PoseModel {
         /// The specific time in ms in the animation to render. The default is to render the start
         /// of the animation, or the default pose of the model if there is no animation.
         #[serde(default)]
-        time: f32,
+        time: Milliseconds,
     },
     /// A single filename. An OBJ file will be used as is. For a glTF file, the model will be
     /// rendered as loaded regardless of the animations present in the file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
     clippy::len_without_is_empty,
     clippy::large_enum_variant,
     clippy::unneeded_field_pattern,
+    clippy::match_ref_pats,
 )]
 #![deny(bare_trait_objects)] // Prefer Box<dyn Trait> over Box<Trait>
 #![deny(unused_must_use)] // Ignoring a Result is usually a sign of trouble

--- a/src/math.rs
+++ b/src/math.rs
@@ -86,3 +86,25 @@ impl Degrees {
         self.0
     }
 }
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Milliseconds(f32);
+
+impl Milliseconds {
+    pub fn from_msec(value: f32) -> Self {
+        Milliseconds(value)
+    }
+
+    pub fn from_sec(value: f32) -> Self {
+        Milliseconds(value * 1000.0)
+    }
+
+    pub fn to_sec(self) -> f32 {
+        self.0 / 1000.0
+    }
+
+    pub fn to_msec(self) -> f32 {
+        self.0
+    }
+}

--- a/src/query3d/backend.rs
+++ b/src/query3d/backend.rs
@@ -27,6 +27,9 @@ pub enum QueryError {
     #[error("Could not find any matching animation in model file")]
     NoAnimationFound,
 
+    #[error("Multiple animations matched for a single node, please specify an animation name")]
+    AmbiguousAnimation,
+
     #[error("Could not find any matching geometry in model file")]
     NoGeometryFound,
 

--- a/src/query3d/backend/gltf.rs
+++ b/src/query3d/backend/gltf.rs
@@ -12,7 +12,7 @@ use crate::query3d::{GeometryQuery, GeometryFilter, CameraQuery, LightQuery};
 
 use super::{QueryBackend, QueryError};
 
-use animation::Animation;
+use animation::AnimationSet;
 
 /// Represents a single glTF file
 #[derive(Debug)]
@@ -32,7 +32,7 @@ pub struct GltfFile {
     scene_cameras: HashMap<(usize, String), Arc<Camera>>,
     /// Contains the transformation data of the animations
     // This is a mapping of Node ID to all the animations that act on that node
-    animations: HashMap<NodeId, Vec<Animation>>,
+    animations: HashMap<NodeId, AnimationSet>,
 }
 
 impl GltfFile {

--- a/src/query3d/backend/gltf.rs
+++ b/src/query3d/backend/gltf.rs
@@ -384,10 +384,10 @@ impl QueryBackend for GltfFile {
 
             _ => {
                 // Need to split the borrow of self so we don't accidentally get two mut refs
-                let Self {nodes, scenes, default_joint_matrix_texture, ..} = self;
+                let Self {scenes, default_joint_matrix_texture, ..} = self;
 
                 let scene = &scenes[scene_index];
-                let node_world_transforms = nodes.world_transforms(&scene.roots);
+                let node_world_transforms = node_tree.world_transforms(&scene.roots);
 
                 let mut scene_geo = Vec::new();
                 for (parent_trans, node) in scene.roots.iter().flat_map(|&root| node_tree.traverse(root)) {

--- a/src/query3d/backend/gltf.rs
+++ b/src/query3d/backend/gltf.rs
@@ -1,17 +1,18 @@
-// JAMES ADDED - to be moved to separate file afterwards
+mod animation;
+mod keyframes;
+mod interpolate;
 
 use std::sync::Arc;
 use std::path::Path;
 use std::collections::HashMap;
-use std::cmp::min;
 
-use crate::query3d::query::AnimationPosition;
-use crate::math::{Vec3, Quaternion, Mat3, Mat4, Decompose, Milliseconds};
 use crate::scene::{Scene, NodeTree, NodeId, Node, Mesh, Skin, Material, CameraType, LightType};
 use crate::renderer::{Display, ShaderGeometry, JointMatrixTexture, Camera, Light};
 use crate::query3d::{GeometryQuery, GeometryFilter, CameraQuery, LightQuery};
 
 use super::{QueryBackend, QueryError};
+
+use animation::Animation;
 
 /// Represents a single glTF file
 #[derive(Debug)]
@@ -32,175 +33,6 @@ pub struct GltfFile {
     /// Contains the transformation data of the animations
     // This is a mapping of Node ID to all the animations that act on that node
     animations: HashMap<NodeId, Vec<Animation>>,
-}
-
-#[derive(Debug)]
-enum Interpolation {
-    Linear,
-    Step,
-}
-
-trait Interpolate {
-    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Self, next_keyframe: Self) -> Self;
-}
-
-impl Interpolate for Vec3 {
-    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Vec3, next_keyframe: Vec3) -> Vec3 {
-        use Interpolation::*;
-        match interp {
-            Linear => {
-                let [x, y, z] = interpolation::lerp(&prev_keyframe.into_array(), &next_keyframe.into_array(), &t);
-                Vec3 {x, y, z}
-            },
-            Step => prev_keyframe,
-        }
-    }
-}
-
-impl Interpolate for Quaternion {
-    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Quaternion, next_keyframe: Quaternion) -> Quaternion {
-        use Interpolation::*;
-        match interp {
-            Linear => Quaternion::slerp(prev_keyframe, next_keyframe, t),
-            Step => prev_keyframe,
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct Animation {
-    name: Option<String>,
-    scale_keyframes: Option<Keyframes<Vec3>>,
-    rotation_keyframes: Option<Keyframes<Quaternion>>,
-    translation_keyframes: Option<Keyframes<Vec3>>,
-}
-
-impl Animation {
-    // with_name takes Option instead of String to include with Animations without names
-    fn with_name(name: Option<String>) -> Self {
-        Self {
-            name,
-            ..Self::default()
-        }
-    }
-
-    /// Application of animation data by decomposing the current node's transformation matrix and
-    /// replacing the different types of transforms if the keyframes for that transform exist
-    fn apply_at(&self, transform_matrix: &Mat4, anim_pos_time: &AnimationPosition) -> Mat4 {
-        use interpolation::lerp;
-        let mut matrix_transforms = transform_matrix.decompose();
-
-        if let Some(value) = &self.scale_keyframes {
-            let time = match *anim_pos_time {
-                AnimationPosition::Time(t) => t,
-                AnimationPosition::RelativeTime{start_time, weight} => {
-                    Milliseconds::from_msec(lerp(&start_time.to_msec(), &value.end_time().to_msec(), &weight))
-                },
-            };
-            let new_value = match value.surrounding(time) {
-                KeyframeRange::Before(kf) => kf.value,
-                KeyframeRange::After(kf) => kf.value,
-                KeyframeRange::Between(kf1, kf2) => {
-                    let start = kf1.time;
-                    let end = kf2.time;
-                    // The time factor that gives weight to the start or end frame during interpolation
-                    let factor = (time.to_msec() - start.to_msec()) / (end.to_msec() - start.to_msec());
-                    Vec3::interpolate(&value.interpolation, factor, kf1.value, kf2.value)
-                },
-            };
-            matrix_transforms.scale = new_value;
-        }
-        if let Some(value) = &self.rotation_keyframes {
-            let time = match *anim_pos_time {
-                AnimationPosition::Time(t) => t,
-                AnimationPosition::RelativeTime{start_time, weight} => {
-                    Milliseconds::from_msec(lerp(&start_time.to_msec(), &value.end_time().to_msec(), &weight))
-                },
-            };
-            let new_value = match value.surrounding(time) {
-                KeyframeRange::Before(kf) => kf.value,
-                KeyframeRange::After(kf) => kf.value,
-                KeyframeRange::Between(kf1, kf2) => {
-                    let start = kf1.time;
-                    let end = kf2.time;
-                    // The time factor that gives weight to the start or end frame during interpolation
-                    let factor = (time.to_msec() - start.to_msec()) / (end.to_msec() - start.to_msec());
-                    Quaternion::interpolate(&value.interpolation, factor, kf1.value, kf2.value)
-                },
-            };
-            matrix_transforms.rotation = Mat3::from(new_value);
-        }
-        if let Some(value) = &self.translation_keyframes {
-            let time = match *anim_pos_time {
-                AnimationPosition::Time(t) => t,
-                AnimationPosition::RelativeTime{start_time, weight} => {
-                    Milliseconds::from_msec(lerp(&start_time.to_msec(), &value.end_time().to_msec(), &weight))
-                },
-            };
-            let new_value = match value.surrounding(time) {
-                KeyframeRange::Before(kf) => kf.value,
-                KeyframeRange::After(kf) => kf.value,
-                KeyframeRange::Between(kf1, kf2) => {
-                    let start = kf1.time;
-                    let end = kf2.time;
-                    // The time factor that gives weight to the start or end frame during interpolation
-                    let factor = (time.to_msec() - start.to_msec()) / (end.to_msec() - start.to_msec());
-                    Vec3::interpolate(&value.interpolation, factor, kf1.value, kf2.value)
-                },
-            };
-            matrix_transforms.translation = new_value;
-        }
-
-        Mat4::from(matrix_transforms)
-    }
-}
-
-enum KeyframeRange<'a, T> {
-    /// The keyframe before the specified time
-    Before(&'a Frame<T>),
-    /// The keyframes that immediately surround the specified time
-    Between(&'a Frame<T>, &'a Frame<T>),
-    /// The keyframe after the specified time
-    After(&'a Frame<T>),
-}
-
-#[derive(Debug)]
-struct Keyframes<T> {
-    frames: Vec<Frame<T>>,
-    interpolation: Interpolation,
-}
-
-impl<T> Keyframes<T> {
-    /// Retrieves the keyframes immediately surrounding the given time
-    /// A time smaller than that of all keyframes will get back the first keyframe twice
-    /// A time larger than all keyframes gets the last keyframe twice
-    fn surrounding(&self, time: Milliseconds) -> KeyframeRange<T> {
-        // This unwrap is safe for partial_cmp as long as NaN is not one of the comparison values
-        let index = match self.frames.binary_search_by(|frame| frame.time.partial_cmp(&time).unwrap()) {
-            Ok(i) | Err(i) => i,
-        };
-
-        if index == 0 {
-            KeyframeRange::After(&self.frames[index])
-        } else if index == self.frames.len() {
-            KeyframeRange::Before(&self.frames[index - 1])
-        } else {
-            let left_index = index - 1;
-            let right_index = min(index, self.frames.len() - 1);
-            KeyframeRange::Between(&self.frames[left_index], &self.frames[right_index])
-        }
-    }
-
-    fn end_time(&self) -> Milliseconds {
-        let last_index = self.frames.len() - 1;
-        self.frames[last_index].time
-    }
-}
-
-#[derive(Debug)]
-struct Frame<T> {
-    time: Milliseconds,
-    value: T,
 }
 
 impl GltfFile {
@@ -243,67 +75,7 @@ impl GltfFile {
         // Get the default scene, or just use the first scene if no default is provided
         let default_scene = document.default_scene().map(|scene| scene.index()).unwrap_or(0);
 
-        let mut animations = HashMap::new();
-
-        for anim_data in document.animations() {
-            let anim_name = anim_data.name();
-            for channel in anim_data.channels() {
-                let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
-                let interpolation = match channel.sampler().interpolation() {
-                    gltf::animation::Interpolation::Linear => Interpolation::Linear,
-                    gltf::animation::Interpolation::Step => Interpolation::Step,
-                    //TODO - In order to support cubicspline interpolation, we need to change how we're storing the data
-                    // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#animation-samplerinterpolation
-                    gltf::animation::Interpolation::CubicSpline => unimplemented!("Cubicspline interpolation is not supported!"),
-                };
-
-                // Create Animation
-                let anims = animations.entry(NodeId::from_gltf(&channel.target().node())).or_insert_with(|| Vec::new());
-                let anim = anims.iter_mut().find(|a: &&mut Animation| a.name.as_deref() == anim_name);
-                let mut anim = match anim {
-                    Some(anim) => anim,
-                    None => {
-                        anims.push(Animation::with_name(anim_name.map(String::from)));
-                        // This unwrap is safe because we just pushed in an animation
-                        anims.last_mut().unwrap()
-                    }
-                };
-
-                // Create Keyframes
-                use gltf::animation::util::ReadOutputs::*;
-                let key_times = reader.read_inputs().expect("Animation detected with no sampler input values");
-                match reader.read_outputs().expect("Animation detected with no sampler output values") {
-                    Scales(scale) => {
-                        assert!(anim.scale_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of scale keyframes");
-                        let keyframes = Keyframes {
-                            frames: key_times.zip(scale)
-                                .map(|(time, output)| Frame {time: Milliseconds::from_sec(time), value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(),
-                            interpolation,
-                        };
-                        anim.scale_keyframes = Some(keyframes);
-                    },
-                    Rotations(rot) => {
-                        assert!(anim.rotation_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of rotation keyframes");
-                        let keyframes = Keyframes {
-                            frames: key_times.zip(rot.into_f32())
-                                .map(|(time, [x, y, z, w])| Frame {time: Milliseconds::from_sec(time), value: Quaternion::from_xyzw(x, y, z, w)}).collect::<Vec<Frame<Quaternion>>>(),
-                            interpolation,
-                        };
-                        anim.rotation_keyframes = Some(keyframes);
-                    },
-                    Translations(trans) => {
-                        assert!(anim.translation_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of translation keyframes");
-                        let keyframes = Keyframes {
-                            frames: key_times.zip(trans)
-                                .map(|(time, output)| Frame {time: Milliseconds::from_sec(time), value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(),
-                            interpolation,
-                        };
-                        anim.translation_keyframes = Some(keyframes);
-                    },
-                    MorphTargetWeights(_) => unimplemented!("Morph target animations are not supported yet"),
-                };
-            }
-        }
+        let animations = animation::from_animations(document.animations(), &buffers);
 
         Ok(Self {
             default_scene,

--- a/src/query3d/backend/gltf.rs
+++ b/src/query3d/backend/gltf.rs
@@ -1,7 +1,6 @@
 // JAMES ADDED - to be moved to separate file afterwards
 use gltf::animation::util::ReadOutputs::*;
-use gltf::animation::Property;
-use crate::math::Vec3;
+use crate::math::{Vec3, Quaternion};
 
 
 use std::sync::Arc;
@@ -38,7 +37,9 @@ pub struct GltfFile {
 #[derive(Debug, Default)]
 struct Animation {
     name: Option<String>,
-    translation_keyframes: Option<Keyframes>,
+    scale_keyframes: Option<Keyframes<Vec3>>,
+    rotation_keyframes: Option<Keyframes<Quaternion>>,
+    translation_keyframes: Option<Keyframes<Vec3>>,
 }
 
 impl Animation {
@@ -52,15 +53,22 @@ impl Animation {
 }
 
 #[derive(Debug)]
-struct Keyframes {
-    frames: Vec<Frame>,
-    interpolation: String,
+struct Keyframes<T> {
+    frames: Vec<Frame<T>>,
+    interpolation: Interpolation,
 }
 
 #[derive(Debug)]
-struct Frame {
+struct Frame<T> {
     time: f32,
-    value: Vec3,
+    value: T,
+}
+
+#[derive(Debug)]
+enum Interpolation {
+    Linear,
+    Step,
+    CubicSpline,
 }
 
 impl GltfFile {
@@ -103,56 +111,53 @@ impl GltfFile {
         // Get the default scene, or just use the first scene if no default is provided
         let default_scene = document.default_scene().map(|scene| scene.index()).unwrap_or(0);
 
-        // for anim in document.animations() {
-        //     for channel in anim.channels() {
-        //         let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
-        //         println!("{:?}", reader.read_inputs().unwrap().collect::<Vec<_>>());
-        //         match reader.read_outputs().unwrap() {
-        //             Translations(x) => println!("Trans: {:?}", x.collect::<Vec<_>>()),
-        //             Rotations(x) => println!("Rot: {:?}", x.into_f32().collect::<Vec<_>>()),
-        //             Scales (x) => println!("Scale: {:?}", x.collect::<Vec<_>>()),
-        //             _ => println!("Morph"),
-        //         };
-        //     }
-        // }
-
-        let mut animations: HashMap<usize, Vec<Animation>> = HashMap::new();
+        let mut animations = HashMap::new();
 
         for anim_data in document.animations() {
             let anim_name = anim_data.name();
             for channel in anim_data.channels() {
                 let node_id = channel.target().node().index();
-                let transformation = channel.target().property();
                 let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
                 let interpolation = match channel.sampler().interpolation() {
-                    Linear => String::from("Linear"),
-                    Step => String::from("Step"),
-                    CubicSpline => String::from("CubicSpline"),
+                    gltf::animation::Interpolation::Linear => Interpolation::Linear,
+                    gltf::animation::Interpolation::Step => Interpolation::Step,
+                    gltf::animation::Interpolation::CubicSpline => Interpolation::CubicSpline,
                 };
+                //TODO - add in own interpolation enum and use that instead of strings
 
                 // Create Animation
-                let mut anim_vec = animations.entry(node_id).or_insert_with(|| Vec::new());
-                let anim = anim_vec.iter_mut().find(|a| a.name == anim_name.map(String::from));
+                let anims = animations.entry(node_id).or_insert_with(|| Vec::new());
+                let anim = anims.iter_mut().find(|a: &&mut Animation| a.name.as_deref() == anim_name);
                 let mut anim = match anim {
                     Some(anim) => anim,
                     None => {
-                        anim_vec.push(Animation::with_name(anim_name.map(String::from)));
+                        anims.push(Animation::with_name(anim_name.map(String::from)));
                         // This unwrap is safe because we just pushed in an animation
-                        anim_vec.last_mut().unwrap()
+                        anims.last_mut().unwrap()
                     }
                 };
 
                 // Create Keyframes
                 let key_times = reader.read_inputs().expect("Animation detected with no sampler input values");
                 match reader.read_outputs().expect("Animation detected with no sampler output values") {
+                    Scales(scale) => {
+                        assert!(anim.scale_keyframes.is_none());
+                        let key_frames = Keyframes {frames: key_times.zip(scale)
+                            .map(|(time, output)| Frame {time, value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(), interpolation};
+                        anim.scale_keyframes = Some(key_frames);
+                    },
+                    Rotations(rot) => {
+                        assert!(anim.rotation_keyframes.is_none());
+                        let key_frames = Keyframes {frames: key_times.zip(rot.into_f32())
+                            .map(|(time, [x, y, z, w])| Frame {time, value: Quaternion::from_xyzw(x, y, z, w)}).collect::<Vec<Frame<Quaternion>>>(), interpolation};
+                        anim.rotation_keyframes = Some(key_frames);
+                    },
                     Translations(trans) => {
                         assert!(anim.translation_keyframes.is_none());
                         let key_frames = Keyframes {frames: key_times.zip(trans)
-                            .map(|(time, output)| Frame {time, value: Vec3::from(output)}).collect::<Vec<Frame>>(), interpolation};
+                            .map(|(time, output)| Frame {time, value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(), interpolation};
                         anim.translation_keyframes = Some(key_frames);
-                        }
-                    Rotations(rot) => todo!(),
-                    Scales(scale) => todo!(),
+                    },
                     _ => todo!(), //Morph stuff
                 };
             }

--- a/src/query3d/backend/gltf.rs
+++ b/src/query3d/backend/gltf.rs
@@ -20,6 +20,9 @@ pub struct GltfFile {
     default_scene: usize,
     nodes: Arc<NodeTree>,
     scenes: Vec<Arc<Scene>>,
+    /// This is a mapping of Node ID to all the animations that act on that node
+    animations: HashMap<NodeId, AnimationSet>,
+
     /// Cache the default joint matrix texture so we don't upload it over and over again
     default_joint_matrix_texture: Option<Arc<JointMatrixTexture>>,
     /// Cache the geometry of the entire scene, referenced by scene index
@@ -30,9 +33,6 @@ pub struct GltfFile {
     scene_first_camera: Option<Arc<Camera>>,
     /// Cache each camera by scene index and name
     scene_cameras: HashMap<(usize, String), Arc<Camera>>,
-    /// Contains the transformation data of the animations
-    // This is a mapping of Node ID to all the animations that act on that node
-    animations: HashMap<NodeId, AnimationSet>,
 }
 
 impl GltfFile {
@@ -81,12 +81,13 @@ impl GltfFile {
             default_scene,
             nodes,
             scenes,
+            animations,
+
             default_joint_matrix_texture: None,
             scene_shader_geometry: HashMap::new(),
             scene_lights: HashMap::new(),
             scene_first_camera: None,
             scene_cameras: HashMap::new(),
-            animations,
         })
     }
 

--- a/src/query3d/backend/gltf/animation.rs
+++ b/src/query3d/backend/gltf/animation.rs
@@ -18,6 +18,16 @@ impl AnimationSet {
         self.anims.iter_mut().find(|anim| anim.name.as_deref() == name)
     }
 
+    /// Iterates over the animation set, optionally only returning animations with the given name
+    ///
+    /// If `name` is None, all the animations will be returned
+    pub fn filter<'a>(&'a self, name: Option<&'a str>) -> impl Iterator<Item=&Animation> + 'a {
+        self.anims.iter().filter(move |anim| match name {
+            None => true,
+            Some(name) => anim.name.as_deref() == Some(name),
+        })
+    }
+
     /// Inserts an animation into the animation set. You guarantee that no previously inserted
     /// animation has the same name.
     pub fn insert(&mut self, anim: Animation) -> &mut Animation {
@@ -122,7 +132,7 @@ pub fn from_animations<'a>(
             let node_id = NodeId::from_gltf(&channel.target().node());
             let anim_set = animations.entry(node_id).or_default();
 
-            let mut anim = match anim_set.animation_mut(anim_name) {
+            let anim = match anim_set.animation_mut(anim_name) {
                 Some(anim) => anim,
                 None => anim_set.insert(Animation::with_name(anim_name)),
             };

--- a/src/query3d/backend/gltf/animation.rs
+++ b/src/query3d/backend/gltf/animation.rs
@@ -1,0 +1,165 @@
+use std::collections::HashMap;
+
+use crate::query3d::query::AnimationPosition;
+use crate::math::{Milliseconds, Vec3, Quaternion, Mat4, Mat3, Decompose};
+use crate::scene::NodeId;
+
+use super::keyframes::{Keyframes, KeyframeRange, Frame};
+use super::interpolate::{Interpolate, Interpolation};
+
+#[derive(Debug, Default)]
+pub struct Animation {
+    pub name: Option<String>,
+    pub scale_keyframes: Option<Keyframes<Vec3>>,
+    pub rotation_keyframes: Option<Keyframes<Quaternion>>,
+    pub translation_keyframes: Option<Keyframes<Vec3>>,
+}
+
+impl Animation {
+    // with_name takes Option instead of String to include with Animations without names
+    pub fn with_name(name: Option<String>) -> Self {
+        Self {
+            name,
+            ..Self::default()
+        }
+    }
+
+    /// Application of animation data by decomposing the current node's transformation matrix and
+    /// replacing the different types of transforms if the keyframes for that transform exist
+    pub fn apply_at(&self, transform_matrix: &Mat4, anim_pos_time: &AnimationPosition) -> Mat4 {
+        use interpolation::lerp;
+        let mut matrix_transforms = transform_matrix.decompose();
+
+        if let Some(value) = &self.scale_keyframes {
+            let time = match *anim_pos_time {
+                AnimationPosition::Time(t) => t,
+                AnimationPosition::RelativeTime{start_time, weight} => {
+                    Milliseconds::from_msec(lerp(&start_time.to_msec(), &value.end_time().to_msec(), &weight))
+                },
+            };
+            let new_value = match value.surrounding(time) {
+                KeyframeRange::Before(kf) => kf.value,
+                KeyframeRange::After(kf) => kf.value,
+                KeyframeRange::Between(kf1, kf2) => {
+                    let start = kf1.time;
+                    let end = kf2.time;
+                    // The time factor that gives weight to the start or end frame during interpolation
+                    let factor = (time.to_msec() - start.to_msec()) / (end.to_msec() - start.to_msec());
+                    Vec3::interpolate(&value.interpolation, factor, kf1.value, kf2.value)
+                },
+            };
+            matrix_transforms.scale = new_value;
+        }
+        if let Some(value) = &self.rotation_keyframes {
+            let time = match *anim_pos_time {
+                AnimationPosition::Time(t) => t,
+                AnimationPosition::RelativeTime{start_time, weight} => {
+                    Milliseconds::from_msec(lerp(&start_time.to_msec(), &value.end_time().to_msec(), &weight))
+                },
+            };
+            let new_value = match value.surrounding(time) {
+                KeyframeRange::Before(kf) => kf.value,
+                KeyframeRange::After(kf) => kf.value,
+                KeyframeRange::Between(kf1, kf2) => {
+                    let start = kf1.time;
+                    let end = kf2.time;
+                    // The time factor that gives weight to the start or end frame during interpolation
+                    let factor = (time.to_msec() - start.to_msec()) / (end.to_msec() - start.to_msec());
+                    Quaternion::interpolate(&value.interpolation, factor, kf1.value, kf2.value)
+                },
+            };
+            matrix_transforms.rotation = Mat3::from(new_value);
+        }
+        if let Some(value) = &self.translation_keyframes {
+            let time = match *anim_pos_time {
+                AnimationPosition::Time(t) => t,
+                AnimationPosition::RelativeTime{start_time, weight} => {
+                    Milliseconds::from_msec(lerp(&start_time.to_msec(), &value.end_time().to_msec(), &weight))
+                },
+            };
+            let new_value = match value.surrounding(time) {
+                KeyframeRange::Before(kf) => kf.value,
+                KeyframeRange::After(kf) => kf.value,
+                KeyframeRange::Between(kf1, kf2) => {
+                    let start = kf1.time;
+                    let end = kf2.time;
+                    // The time factor that gives weight to the start or end frame during interpolation
+                    let factor = (time.to_msec() - start.to_msec()) / (end.to_msec() - start.to_msec());
+                    Vec3::interpolate(&value.interpolation, factor, kf1.value, kf2.value)
+                },
+            };
+            matrix_transforms.translation = new_value;
+        }
+
+        Mat4::from(matrix_transforms)
+    }
+}
+
+pub fn from_animations<'a>(
+    doc_anims: impl Iterator<Item=gltf::Animation<'a>>,
+    buffers: &[gltf::buffer::Data],
+) -> HashMap<NodeId, Vec<Animation>> {
+    let mut animations = HashMap::new();
+
+    for anim_data in doc_anims {
+        let anim_name = anim_data.name();
+        for channel in anim_data.channels() {
+            let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
+            let interpolation = match channel.sampler().interpolation() {
+                gltf::animation::Interpolation::Linear => Interpolation::Linear,
+                gltf::animation::Interpolation::Step => Interpolation::Step,
+                //TODO - In order to support cubicspline interpolation, we need to change how we're storing the data
+                // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#animation-samplerinterpolation
+                gltf::animation::Interpolation::CubicSpline => unimplemented!("Cubicspline interpolation is not supported!"),
+            };
+
+            // Create Animation
+            let anims = animations.entry(NodeId::from_gltf(&channel.target().node())).or_insert_with(|| Vec::new());
+            let anim = anims.iter_mut().find(|a: &&mut Animation| a.name.as_deref() == anim_name);
+            let mut anim = match anim {
+                Some(anim) => anim,
+                None => {
+                    anims.push(Animation::with_name(anim_name.map(String::from)));
+                    // This unwrap is safe because we just pushed in an animation
+                    anims.last_mut().unwrap()
+                }
+            };
+
+            // Create Keyframes
+            use gltf::animation::util::ReadOutputs::*;
+            let key_times = reader.read_inputs().expect("Animation detected with no sampler input values");
+            match reader.read_outputs().expect("Animation detected with no sampler output values") {
+                Scales(scale) => {
+                    assert!(anim.scale_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of scale keyframes");
+                    let keyframes = Keyframes {
+                        frames: key_times.zip(scale)
+                        .map(|(time, output)| Frame {time: Milliseconds::from_sec(time), value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(),
+                        interpolation,
+                    };
+                    anim.scale_keyframes = Some(keyframes);
+                },
+                Rotations(rot) => {
+                    assert!(anim.rotation_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of rotation keyframes");
+                    let keyframes = Keyframes {
+                        frames: key_times.zip(rot.into_f32())
+                        .map(|(time, [x, y, z, w])| Frame {time: Milliseconds::from_sec(time), value: Quaternion::from_xyzw(x, y, z, w)}).collect::<Vec<Frame<Quaternion>>>(),
+                        interpolation,
+                    };
+                    anim.rotation_keyframes = Some(keyframes);
+                },
+                Translations(trans) => {
+                    assert!(anim.translation_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of translation keyframes");
+                    let keyframes = Keyframes {
+                        frames: key_times.zip(trans)
+                        .map(|(time, output)| Frame {time: Milliseconds::from_sec(time), value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(),
+                        interpolation,
+                    };
+                    anim.translation_keyframes = Some(keyframes);
+                },
+                MorphTargetWeights(_) => unimplemented!("Morph target animations are not supported yet"),
+            };
+        }
+    }
+
+    animations
+}

--- a/src/query3d/backend/gltf/animation.rs
+++ b/src/query3d/backend/gltf/animation.rs
@@ -4,24 +4,84 @@ use crate::query3d::query::AnimationPosition;
 use crate::math::{Milliseconds, Vec3, Quaternion, Mat4, Mat3, Decompose};
 use crate::scene::NodeId;
 
-use super::keyframes::{Keyframes, Frame};
+use super::keyframes::Keyframes;
 use super::interpolate::Interpolation;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
+pub struct AnimationSet {
+    anims: Vec<Animation>,
+}
+
+impl AnimationSet {
+    pub fn animation_mut(&mut self, name: Option<&str>) -> Option<&mut Animation> {
+        // By construction, there should only ever be one animation with a given name
+        self.anims.iter_mut().find(|anim| anim.name.as_deref() == name)
+    }
+
+    /// Inserts an animation into the animation set. You guarantee that no previously inserted
+    /// animation has the same name.
+    pub fn insert(&mut self, anim: Animation) -> &mut Animation {
+        self.anims.push(anim);
+        // This unwrap is safe because we just pushed in an animation
+        self.anims.last_mut().unwrap()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
 pub struct Animation {
     pub name: Option<String>,
-    pub scale_keyframes: Option<Keyframes<Vec3>>,
-    pub rotation_keyframes: Option<Keyframes<Quaternion>>,
-    pub translation_keyframes: Option<Keyframes<Vec3>>,
+    pub scale: Option<Keyframes<Vec3>>,
+    pub rotation: Option<Keyframes<Quaternion>>,
+    pub translation: Option<Keyframes<Vec3>>,
 }
 
 impl Animation {
     // with_name takes Option instead of String to include with Animations without names
-    pub fn with_name(name: Option<String>) -> Self {
+    pub fn with_name(name: Option<&str>) -> Self {
         Self {
-            name,
+            name: name.map(String::from),
             ..Self::default()
         }
+    }
+
+    pub fn add_keyframes(
+        &mut self,
+        channel: gltf::animation::Channel,
+        buffers: &[gltf::buffer::Data],
+        interpolation: Interpolation,
+    ) {
+        let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
+        let times = reader.read_inputs().expect("Animation detected with no sampler input values")
+            .map(|time| Milliseconds::from_sec(time));
+
+        use gltf::animation::util::ReadOutputs::*;
+        match reader.read_outputs().expect("Animation detected with no sampler output values") {
+            Scales(scales) => {
+                assert!(self.scale.is_none(),
+                    "Did not expect animation with the same name to have multiple sets of scale keyframes");
+
+                let values = scales.map(Vec3::from);
+                self.scale = Some(Keyframes::new(times, values, interpolation));
+            },
+
+            Rotations(rotations) => {
+                assert!(self.rotation.is_none(),
+                    "Did not expect animation with the same name to have multiple sets of rotation keyframes");
+
+                let values = rotations.into_f32().map(|[x, y, z, w]| Quaternion::from_xyzw(x, y, z, w));
+                self.rotation = Some(Keyframes::new(times, values, interpolation));
+            },
+
+            Translations(translations) => {
+                assert!(self.translation.is_none(),
+                    "Did not expect animation with the same name to have multiple sets of translation keyframes");
+
+                let values = translations.map(Vec3::from);
+                self.translation = Some(Keyframes::new(times, values, interpolation));
+            },
+
+            MorphTargetWeights(_) => unimplemented!("Morph target animations are not supported yet"),
+        };
     }
 
     /// Application of animation data by decomposing the current node's transformation matrix and
@@ -29,15 +89,15 @@ impl Animation {
     pub fn apply_at(&self, transform_matrix: &Mat4, pos: &AnimationPosition) -> Mat4 {
         let mut matrix_transforms = transform_matrix.decompose();
 
-        if let Some(keyframes) = &self.scale_keyframes {
+        if let Some(keyframes) = &self.scale {
             let new_value = keyframes.value_at(pos);
             matrix_transforms.scale = new_value;
         }
-        if let Some(keyframes) = &self.rotation_keyframes {
+        if let Some(keyframes) = &self.rotation {
             let new_value = keyframes.value_at(pos);
             matrix_transforms.rotation = Mat3::from(new_value);
         }
-        if let Some(keyframes) = &self.translation_keyframes {
+        if let Some(keyframes) = &self.translation {
             let new_value = keyframes.value_at(pos);
             matrix_transforms.translation = new_value;
         }
@@ -49,66 +109,25 @@ impl Animation {
 pub fn from_animations<'a>(
     doc_anims: impl Iterator<Item=gltf::Animation<'a>>,
     buffers: &[gltf::buffer::Data],
-) -> HashMap<NodeId, Vec<Animation>> {
-    let mut animations = HashMap::new();
+) -> HashMap<NodeId, AnimationSet> {
+    let mut animations: HashMap<NodeId, AnimationSet> = HashMap::new();
 
     for anim_data in doc_anims {
         let anim_name = anim_data.name();
+
         for channel in anim_data.channels() {
-            let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
-            let interpolation = match channel.sampler().interpolation() {
-                gltf::animation::Interpolation::Linear => Interpolation::Linear,
-                gltf::animation::Interpolation::Step => Interpolation::Step,
-                //TODO - In order to support cubicspline interpolation, we need to change how we're storing the data
-                // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#animation-samplerinterpolation
-                gltf::animation::Interpolation::CubicSpline => unimplemented!("Cubicspline interpolation is not supported!"),
-            };
+            let interpolation = channel.sampler().interpolation().into();
 
             // Create Animation
-            let anims = animations.entry(NodeId::from_gltf(&channel.target().node())).or_insert_with(|| Vec::new());
-            let anim = anims.iter_mut().find(|a: &&mut Animation| a.name.as_deref() == anim_name);
-            let mut anim = match anim {
+            let node_id = NodeId::from_gltf(&channel.target().node());
+            let anim_set = animations.entry(node_id).or_default();
+
+            let mut anim = match anim_set.animation_mut(anim_name) {
                 Some(anim) => anim,
-                None => {
-                    anims.push(Animation::with_name(anim_name.map(String::from)));
-                    // This unwrap is safe because we just pushed in an animation
-                    anims.last_mut().unwrap()
-                }
+                None => anim_set.insert(Animation::with_name(anim_name)),
             };
 
-            // Create Keyframes
-            use gltf::animation::util::ReadOutputs::*;
-            let key_times = reader.read_inputs().expect("Animation detected with no sampler input values");
-            match reader.read_outputs().expect("Animation detected with no sampler output values") {
-                Scales(scale) => {
-                    assert!(anim.scale_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of scale keyframes");
-                    let keyframes = Keyframes {
-                        frames: key_times.zip(scale)
-                        .map(|(time, output)| Frame {time: Milliseconds::from_sec(time), value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(),
-                        interpolation,
-                    };
-                    anim.scale_keyframes = Some(keyframes);
-                },
-                Rotations(rot) => {
-                    assert!(anim.rotation_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of rotation keyframes");
-                    let keyframes = Keyframes {
-                        frames: key_times.zip(rot.into_f32())
-                        .map(|(time, [x, y, z, w])| Frame {time: Milliseconds::from_sec(time), value: Quaternion::from_xyzw(x, y, z, w)}).collect::<Vec<Frame<Quaternion>>>(),
-                        interpolation,
-                    };
-                    anim.rotation_keyframes = Some(keyframes);
-                },
-                Translations(trans) => {
-                    assert!(anim.translation_keyframes.is_none(), "Did not expect animation with the same name to have multiple sets of translation keyframes");
-                    let keyframes = Keyframes {
-                        frames: key_times.zip(trans)
-                        .map(|(time, output)| Frame {time: Milliseconds::from_sec(time), value: Vec3::from(output)}).collect::<Vec<Frame<Vec3>>>(),
-                        interpolation,
-                    };
-                    anim.translation_keyframes = Some(keyframes);
-                },
-                MorphTargetWeights(_) => unimplemented!("Morph target animations are not supported yet"),
-            };
+            anim.add_keyframes(channel, buffers, interpolation);
         }
     }
 

--- a/src/query3d/backend/gltf/interpolate.rs
+++ b/src/query3d/backend/gltf/interpolate.rs
@@ -1,0 +1,34 @@
+use crate::math::{Vec3, Quaternion};
+
+#[derive(Debug)]
+pub enum Interpolation {
+    Linear,
+    Step,
+}
+
+pub trait Interpolate {
+    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Self, next_keyframe: Self) -> Self;
+}
+
+impl Interpolate for Vec3 {
+    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Vec3, next_keyframe: Vec3) -> Vec3 {
+        use Interpolation::*;
+        match interp {
+            Linear => {
+                let [x, y, z] = interpolation::lerp(&prev_keyframe.into_array(), &next_keyframe.into_array(), &t);
+                Vec3 {x, y, z}
+            },
+            Step => prev_keyframe,
+        }
+    }
+}
+
+impl Interpolate for Quaternion {
+    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Quaternion, next_keyframe: Quaternion) -> Quaternion {
+        use Interpolation::*;
+        match interp {
+            Linear => Quaternion::slerp(prev_keyframe, next_keyframe, t),
+            Step => prev_keyframe,
+        }
+    }
+}

--- a/src/query3d/backend/gltf/interpolate.rs
+++ b/src/query3d/backend/gltf/interpolate.rs
@@ -6,6 +6,20 @@ pub enum Interpolation {
     Step,
 }
 
+impl From<gltf::animation::Interpolation> for Interpolation {
+    fn from(interp: gltf::animation::Interpolation) -> Self {
+        use gltf::animation::Interpolation::*;
+        match interp {
+            Linear => Interpolation::Linear,
+            Step => Interpolation::Step,
+            //TODO - In order to support cubicspline interpolation, we need to change how we're
+            // storing the data
+            // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#animation-samplerinterpolation
+            CubicSpline => unimplemented!("Cubicspline interpolation is not supported!"),
+        }
+    }
+}
+
 pub trait Interpolate {
     /// Interpolate between two values using the given method.
     ///

--- a/src/query3d/backend/gltf/interpolate.rs
+++ b/src/query3d/backend/gltf/interpolate.rs
@@ -1,34 +1,40 @@
 use crate::math::{Vec3, Quaternion};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Interpolation {
     Linear,
     Step,
 }
 
 pub trait Interpolate {
-    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Self, next_keyframe: Self) -> Self;
+    /// Interpolate between two values using the given method.
+    ///
+    /// `weight` is always between 0.0 and 1.0
+    fn interpolate(method: Interpolation, weight: f32, start: &Self, end: &Self) -> Self;
 }
 
 impl Interpolate for Vec3 {
-    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Vec3, next_keyframe: Vec3) -> Vec3 {
+    fn interpolate(method: Interpolation, weight: f32, start: &Vec3, end: &Vec3) -> Vec3 {
         use Interpolation::*;
-        match interp {
+        match method {
             Linear => {
-                let [x, y, z] = interpolation::lerp(&prev_keyframe.into_array(), &next_keyframe.into_array(), &t);
+                let start = start.into_array();
+                let end = end.into_array();
+                let [x, y, z] = interpolation::lerp(&start, &end, &weight);
+
                 Vec3 {x, y, z}
             },
-            Step => prev_keyframe,
+            Step => *start,
         }
     }
 }
 
 impl Interpolate for Quaternion {
-    fn interpolate(interp: &Interpolation, t: f32, prev_keyframe: Quaternion, next_keyframe: Quaternion) -> Quaternion {
+    fn interpolate(method: Interpolation, weight: f32, start: &Quaternion, end: &Quaternion) -> Quaternion {
         use Interpolation::*;
-        match interp {
-            Linear => Quaternion::slerp(prev_keyframe, next_keyframe, t),
-            Step => prev_keyframe,
+        match method {
+            Linear => Quaternion::slerp(*start, *end, weight),
+            Step => *start,
         }
     }
 }

--- a/src/query3d/backend/gltf/keyframes.rs
+++ b/src/query3d/backend/gltf/keyframes.rs
@@ -16,13 +16,26 @@ pub enum KeyframeRange<'a, T> {
     After(&'a Frame<T>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Keyframes<T> {
     pub frames: Vec<Frame<T>>,
     pub interpolation: Interpolation,
 }
 
 impl<T> Keyframes<T> {
+    pub fn new(
+        times: impl Iterator<Item=Milliseconds>,
+        values: impl Iterator<Item=T>,
+        interpolation: Interpolation,
+    ) -> Self {
+        let frames = times.zip(values).map(|(time, value)| Frame {time, value}).collect();
+
+        Self {
+            frames,
+            interpolation,
+        }
+    }
+
     /// Retrieves the keyframes immediately surrounding the given time
     /// A time smaller than that of all keyframes will get back the first keyframe twice
     /// A time larger than all keyframes gets the last keyframe twice
@@ -74,7 +87,7 @@ impl<T> Keyframes<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Frame<T> {
     pub time: Milliseconds,
     pub value: T,

--- a/src/query3d/backend/gltf/keyframes.rs
+++ b/src/query3d/backend/gltf/keyframes.rs
@@ -1,0 +1,53 @@
+use std::cmp::min;
+
+use crate::math::Milliseconds;
+
+use super::interpolate::Interpolation;
+
+pub enum KeyframeRange<'a, T> {
+    /// The keyframe before the specified time
+    Before(&'a Frame<T>),
+    /// The keyframes that immediately surround the specified time
+    Between(&'a Frame<T>, &'a Frame<T>),
+    /// The keyframe after the specified time
+    After(&'a Frame<T>),
+}
+
+#[derive(Debug)]
+pub struct Keyframes<T> {
+    pub frames: Vec<Frame<T>>,
+    pub interpolation: Interpolation,
+}
+
+impl<T> Keyframes<T> {
+    /// Retrieves the keyframes immediately surrounding the given time
+    /// A time smaller than that of all keyframes will get back the first keyframe twice
+    /// A time larger than all keyframes gets the last keyframe twice
+    pub fn surrounding(&self, time: Milliseconds) -> KeyframeRange<T> {
+        // This unwrap is safe for partial_cmp as long as NaN is not one of the comparison values
+        let index = match self.frames.binary_search_by(|frame| frame.time.partial_cmp(&time).unwrap()) {
+            Ok(i) | Err(i) => i,
+        };
+
+        if index == 0 {
+            KeyframeRange::After(&self.frames[index])
+        } else if index == self.frames.len() {
+            KeyframeRange::Before(&self.frames[index - 1])
+        } else {
+            let left_index = index - 1;
+            let right_index = min(index, self.frames.len() - 1);
+            KeyframeRange::Between(&self.frames[left_index], &self.frames[right_index])
+        }
+    }
+
+    pub fn end_time(&self) -> Milliseconds {
+        let last_index = self.frames.len() - 1;
+        self.frames[last_index].time
+    }
+}
+
+#[derive(Debug)]
+pub struct Frame<T> {
+    pub time: Milliseconds,
+    pub value: T,
+}

--- a/src/query3d/backend/gltf/scene_anim_query_cache.rs
+++ b/src/query3d/backend/gltf/scene_anim_query_cache.rs
@@ -1,18 +1,64 @@
-use crate::query3d::AnimationQuery;
+use std::collections::HashMap;
+
+use crate::query3d::{AnimationQuery, AnimationPosition};
+
+/// A cache for animation positions
+///
+/// The idea is that because floating point numbers can't be hashed, we'll instead define a
+/// tolerance within which two floating point numbers are considered equal. We can then use
+/// binary search to fairly accurately find a match. Note that we are ignoring NaN here.
+#[derive(Debug)]
+pub struct AnimPosCache<T> {
+    entries: Vec<(AnimationPosition, T)>,
+}
+
+// Need to manually implement default because the derive requires T: Default
+impl<T> Default for AnimPosCache<T> {
+    fn default() -> Self {
+        Self {
+            entries: Default::default(),
+        }
+    }
+}
+
+impl<T> AnimPosCache<T> {
+    pub fn get(&self, pos: &AnimationPosition) -> Option<&T> {
+        todo!()
+    }
+
+    pub fn insert(&mut self, pos: &AnimationPosition, value: T) {
+        todo!()
+    }
+}
 
 /// A cache based on the scene index and the animation query
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SceneAnimQueryCache<T> {
-    //scene_shader_geometry: HashMap<usize, Arc<Vec<Arc<ShaderGeometry>>>>,
-    x: T,
+    /// A cache of (scene index, animation name) to a cache for the animation positions
+    cache: HashMap<(usize, Option<String>), AnimPosCache<T>>,
+}
+
+// Need to manually implement default because the derive requires T: Default
+impl<T> Default for SceneAnimQueryCache<T> {
+    fn default() -> Self {
+        Self {
+            cache: Default::default(),
+        }
+    }
 }
 
 impl<T> SceneAnimQueryCache<T> {
     pub fn get(&self, scene_index: usize, anim_query: &AnimationQuery) -> Option<&T> {
-        todo!()
+        let AnimationQuery {name, position} = anim_query;
+        //TODO: There are potentially some (complex) ways to get around the allocation here, but
+        // it's probably not worth the effort so I opted to ignore it for now.
+        self.cache.get(&(scene_index, name.clone()))
+            .and_then(|pos_cache| pos_cache.get(position))
     }
 
     pub fn insert(&mut self, scene_index: usize, anim_query: &AnimationQuery, value: T) {
-        todo!()
+        let AnimationQuery {name, position} = anim_query;
+        let pos_cache = self.cache.entry((scene_index, name.clone())).or_default();
+        pos_cache.insert(position, value);
     }
 }

--- a/src/query3d/backend/gltf/scene_anim_query_cache.rs
+++ b/src/query3d/backend/gltf/scene_anim_query_cache.rs
@@ -1,6 +1,50 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
+use approx::relative_eq;
+
 use crate::query3d::{AnimationQuery, AnimationPosition};
+
+/// If this value is too small, our cache will be bloated. If the value is too big, the cache will
+/// incorrectly treat different values as the same.
+const TOLERANCE: f32 = 0.0001;
+
+/// Defines a total ordering for floating point numbers by treating numbers that are approximately
+/// the same as equal.
+///
+/// This does not account for NaN values and will probably panic if they are encountered.
+fn approx_cmp(left: f32, right: f32) -> Ordering {
+    if relative_eq!(left, right, epsilon = TOLERANCE) {
+        Ordering::Equal
+    } else {
+        // This will panic if we get NaN
+        left.partial_cmp(&right).unwrap()
+    }
+}
+
+/// Defines a total ordering for animation positions
+fn pos_cmp(left: &AnimationPosition, right: &AnimationPosition) -> Ordering {
+    use AnimationPosition::*;
+    match (left, right) {
+        // Arbitrarily order the different variants
+        (Time(_), RelativeTime {..}) => Ordering::Less,
+        (RelativeTime {..}, Time(_)) => Ordering::Greater,
+
+        // Compare the values if the variants are the same
+        (Time(left), Time(right)) => approx_cmp(left.to_msec(), right.to_msec()),
+
+        (
+            &RelativeTime {start_time: left_start_time, weight: left_weight},
+            &RelativeTime {start_time: right_start_time, weight: right_weight},
+        ) => {
+            // Arbitrarily decided to order by start_time first and then weight
+            match approx_cmp(left_start_time.to_msec(), right_start_time.to_msec()) {
+                Ordering::Equal => approx_cmp(left_weight, right_weight),
+                order => order,
+            }
+        },
+    }
+}
 
 /// A cache for animation positions
 ///
@@ -23,11 +67,18 @@ impl<T> Default for AnimPosCache<T> {
 
 impl<T> AnimPosCache<T> {
     pub fn get(&self, pos: &AnimationPosition) -> Option<&T> {
-        todo!()
+        self.find(pos).ok().map(|i| &self.entries[i].1)
     }
 
     pub fn insert(&mut self, pos: &AnimationPosition, value: T) {
-        todo!()
+        match self.find(pos) {
+            Ok(_) => unreachable!("bug: attempt to re-insert a cached value"),
+            Err(i) => self.entries.insert(i, (pos.clone(), value)),
+        }
+    }
+
+    fn find(&self, pos: &AnimationPosition) -> Result<usize, usize> {
+        self.entries.binary_search_by(|(epos, _)| pos_cmp(epos, pos))
     }
 }
 

--- a/src/query3d/backend/gltf/scene_anim_query_cache.rs
+++ b/src/query3d/backend/gltf/scene_anim_query_cache.rs
@@ -1,0 +1,18 @@
+use crate::query3d::AnimationQuery;
+
+/// A cache based on the scene index and the animation query
+#[derive(Debug, Default)]
+pub struct SceneAnimQueryCache<T> {
+    //scene_shader_geometry: HashMap<usize, Arc<Vec<Arc<ShaderGeometry>>>>,
+    x: T,
+}
+
+impl<T> SceneAnimQueryCache<T> {
+    pub fn get(&self, scene_index: usize, anim_query: &AnimationQuery) -> Option<&T> {
+        todo!()
+    }
+
+    pub fn insert(&mut self, scene_index: usize, anim_query: &AnimationQuery, value: T) {
+        todo!()
+    }
+}

--- a/src/query3d/backend/gltf/scenes.rs
+++ b/src/query3d/backend/gltf/scenes.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+use std::ops::Index;
+
+use crate::scene::Scene;
+
+use super::super::QueryError;
+
+#[derive(Debug, Clone)]
+pub struct Scenes {
+    scenes: Vec<Arc<Scene>>,
+    /// The default scene when no scene name is provided (index into `scenes`)
+    default_scene: usize,
+}
+
+impl Scenes {
+    pub fn new(scenes: Vec<Arc<Scene>>, default_scene: usize) -> Self {
+        Self {
+            scenes,
+            default_scene,
+        }
+    }
+
+    /// Attempts to find the index of a scene with the given name. If name is None, the default
+    /// scene is returned.
+    pub fn query(&self, name: Option<&str>) -> Result<usize, QueryError> {
+        match name {
+            None => Ok(self.default_scene),
+
+            // This assumes that scene names are unique. If they are not unique, we might need to
+            // search for all matching scenes and produce an error if there is more than one result
+            Some(name) => self.scenes.iter()
+                .position(|scene| scene.name.as_deref() == Some(name))
+                .ok_or_else(|| QueryError::UnknownScene {name: name.to_string()}),
+        }
+    }
+}
+
+impl Index<usize> for Scenes {
+    type Output = Arc<Scene>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.scenes[index]
+    }
+}

--- a/src/query3d/query.rs
+++ b/src/query3d/query.rs
@@ -1,3 +1,5 @@
+use crate::math::Milliseconds;
+
 #[derive(Debug, Clone)]
 pub struct GeometryQuery {
     pub models: GeometryFilter,
@@ -31,12 +33,12 @@ pub struct AnimationQuery {
 #[derive(Debug, Clone)]
 pub enum AnimationPosition {
     /// The time in ms on the global animation clock
-    Time(f32),
+    Time(Milliseconds),
     /// The time interpolated between the given start time and up to the time of the last keyframe of the
     /// animation
     RelativeTime {
         /// The start time in ms
-        start_time: f32,
+        start_time: Milliseconds,
         /// A value between 0.0 and 1.0 that specifies the interpolation factor between the
         /// provided start time and the end of the animation. The end of the animation is defined
         /// as the time of its last keyframe.

--- a/src/scene/node.rs
+++ b/src/scene/node.rs
@@ -95,4 +95,11 @@ impl Node {
             _ => None,
         }
     }
+
+    pub fn with_transform(&self, new_transform: Mat4) -> Self {
+        Self {
+            transform: new_transform,
+            ..self.clone()
+        }
+    }
 }

--- a/src/scene/node_tree.rs
+++ b/src/scene/node_tree.rs
@@ -24,6 +24,11 @@ impl NodeWorldTransforms {
         let NodeId(index) = id;
         node_world_transforms[index]
     }
+
+    /// Iterates over all the nodes and their model/world transforms
+    pub fn iter<'a>(&'a self, nodes: &'a NodeTree) -> impl Iterator<Item=(&'a Node, Mat4)> {
+        nodes.iter().map(move |node| (node, self.get(node.id)))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -36,7 +41,7 @@ struct NodeTreeEntry {
     children: Arc<Vec<NodeId>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NodeTree {
     /// The nodes and their children, indexed by the node ID
     nodes: Vec<NodeTreeEntry>,
@@ -92,6 +97,11 @@ impl NodeTree {
     /// Iterate over the child nodes of the given node
     pub fn children(&self, node_id: NodeId) -> impl Iterator<Item=&Node> {
         self.entry(node_id).children.iter().map(move |&id| self.get(id))
+    }
+
+    /// Iterates through all the nodes in the node tree
+    pub fn iter(&self) -> impl Iterator<Item=&Node> {
+        self.nodes.iter().map(|entry| &*entry.node)
     }
 
     /// Returns the computed world transforms of every node

--- a/src/scene/node_tree.rs
+++ b/src/scene/node_tree.rs
@@ -36,7 +36,7 @@ struct NodeTreeEntry {
     children: Arc<Vec<NodeId>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NodeTree {
     /// The nodes and their children, indexed by the node ID
     nodes: Vec<NodeTreeEntry>,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -5,6 +5,7 @@ pub use file_cache::*;
 use std::sync::{Arc, Mutex};
 use std::path::{Path, PathBuf};
 use std::num::NonZeroU32;
+use std::cmp::max;
 
 use interpolation::lerp;
 use thiserror::Error;
@@ -157,9 +158,14 @@ pub fn generate_spritesheet_task(
                 let file = file_cache.open_gltf(&gltf.resolve(base_dir))?;
                 let camera = preset_to_camera(&camera, &file);
 
+                //           | step       => weight
+                // steps = 1 | 0          => 0.0
+                // steps = 2 | 0, 1       => 0.0, 1.0
+                // steps = 3 | 0, 1, 2    => 0.0, 0.5, 1.0
+                // steps = 4 | 0, 1, 2, 3 => 0.0, 0.33, 0.66, 1.0
                 let steps = steps.get();
                 for step in 0..steps {
-                    let weight = step as f32 / (steps - 1) as f32;
+                    let weight = step as f32 / max(steps - 1, 1) as f32;
 
                     nodes.push(RenderNode::RenderedImage(RenderedImage {
                         size: frame_size,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -9,7 +9,7 @@ use std::num::NonZeroU32;
 use interpolation::lerp;
 use thiserror::Error;
 
-use crate::math::{Mat4, Vec3, Rgb};
+use crate::math::{Mat4, Vec3, Rgb, Milliseconds};
 use crate::config;
 use crate::scene::{CameraType, LightType};
 use crate::query3d::{
@@ -159,7 +159,7 @@ pub fn generate_spritesheet_task(
 
                 let steps = steps.get();
                 for step in 0..steps {
-                    let weight = step as f32 / steps as f32;
+                    let weight = step as f32 / (steps - 1) as f32;
 
                     nodes.push(RenderNode::RenderedImage(RenderedImage {
                         size: frame_size,
@@ -182,7 +182,7 @@ pub fn generate_spritesheet_task(
                                     name: name.clone(),
                                     position: match end_time {
                                         Some(end_time) => AnimationPosition::Time(
-                                            lerp(&start_time, &end_time, &weight)
+                                            Milliseconds::from_msec(lerp(&start_time.to_msec(), &end_time.to_msec(), &weight))
                                         ),
 
                                         None => AnimationPosition::RelativeTime {


### PR DESCRIPTION
Fixes #18 

Two changes added:
1. Animation data from GLTF files are stored in our own representation of the animation data for ease of use. (Animation -> Keyframes -> Frames) 
2. Geometry queries now apply transformations from an animation (if specified in the query) to the nodes before any other actions are taken.

Before Change:
![before_animation](https://user-images.githubusercontent.com/14855005/74672481-5d844c00-517b-11ea-8c89-efde34365a43.png)

After Change:
![spritesheet0](https://user-images.githubusercontent.com/14855005/74672520-71c84900-517b-11ea-9af0-6f36452c5014.png)

New code needs to be restructured as most of it is in gltf.rs currently.