### PR TITLE
GUI: camera selection support

### DIFF
--- a/spritec_binding/native/src/lib.rs
+++ b/spritec_binding/native/src/lib.rs
@@ -1,10 +1,10 @@
 use neon::prelude::*;
-use spritec::math::{Rgba, Rgb, Vec3, Mat4, Radians};
+use spritec::math::{Mat4, Quaternion, Radians, Rgb, Rgba, Vec3, Vec4};
 use spritec::query3d::{File, GeometryFilter, GeometryQuery};
 use spritec::renderer::{
+    Camera,
     FileQuery,
     Light,
-    Camera,
     Outline,
     RenderCamera,
     RenderJob,
@@ -14,7 +14,7 @@ use spritec::renderer::{
     Size,
     ThreadRenderContext,
 };
-use spritec::scene::{LightType, CameraType};
+use spritec::scene::{CameraType, LightType};
 use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -26,10 +26,30 @@ fn render_sprite(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
     let width = cx.argument::<JsNumber>(1)?.value() as u32;
     let height = cx.argument::<JsNumber>(2)?.value() as u32;
 
+    // TODO: change to class so that we can set camera separately
+    let cam_position = cx.argument::<JsArrayBuffer>(3)?;
+    let cam_rotation = cx.argument::<JsArrayBuffer>(4)?;
+    let cam_scale = cx.argument::<JsArrayBuffer>(5)?;
+    let cam_aspect_ratio = cx.argument::<JsNumber>(6)?.value() as f32;
+    let cam_near_z = cx.argument::<JsNumber>(7)?.value() as f32;
+    let cam_far_z = cx.argument::<JsNumber>(8)?.value() as f32;
+    let cam_fov_deg = cx.argument::<JsNumber>(9)?.value() as f32;
+
     // TODO: Change to return a class so we can reuse resources
     let mut ctx = ThreadRenderContext::new().expect("Unable to create ThreadRenderContext");
-    let file = Arc::new(Mutex::new(File::open(Path::new(&path)).expect("Unable to open file")));
-    let camera = RenderCamera::Camera(Arc::new(default_camera()));
+    let file = Arc::new(Mutex::new(
+        File::open(Path::new(&path)).expect("Unable to open file"),
+    ));
+
+    let camera = RenderCamera::Camera(Arc::new(create_camera(
+        Vec3::from(take_3(&cx, &cam_position)),
+        Quaternion::from(Vec4::from(take_4(&cx, &cam_rotation))),
+        Vec3::from(take_3(&cx, &cam_scale)),
+        cam_aspect_ratio,
+        cam_near_z,
+        cam_far_z,
+        cam_fov_deg,
+    )));
 
     let job = RenderJob {
         scale: unsafe { NonZeroU32::new_unchecked(1) },
@@ -81,24 +101,48 @@ fn render_sprite(mut cx: FunctionContext) -> JsResult<JsArrayBuffer> {
     Ok(array_buffer)
 }
 
-fn default_camera() -> Camera {
-    let eye = Vec3 {x: 8.0, y: 8.0, z: 8.0};
-    let target = Vec3::zero();
+/// Takes the first three f32 numbers from a JavaScript array buffer
+fn take_3(cx: &FunctionContext, array_buffer: &Handle<JsArrayBuffer>) -> [f32; 3] {
+    cx.borrow(array_buffer, |data| {
+        let slice = data.as_slice::<f32>();
+        [slice[0], slice[1], slice[2]]
+    })
+}
 
+/// Takes the first four f32 numbers from a JavaScript array buffer
+fn take_4(cx: &FunctionContext, array_buffer: &Handle<JsArrayBuffer>) -> [f32; 4] {
+    cx.borrow(array_buffer, |data| {
+        let slice = data.as_slice::<f32>();
+        [slice[0], slice[1], slice[2], slice[3]]
+    })
+}
+
+fn create_camera(
+    position: Vec3,
+    rotation: Quaternion,
+    scale: Vec3,
+    aspect_ratio: f32,
+    near_z: f32,
+    far_z: f32,
+    fov_deg: f32,
+) -> Camera {
     let cam_type = CameraType::Perspective {
         name: None,
-        aspect_ratio: 1.0,
-        field_of_view_y: Radians::from_degrees(40.0),
-        near_z: 0.1,
-        far_z: Some(1000.0),
+        aspect_ratio,
+        field_of_view_y: Radians::from_degrees(fov_deg),
+        near_z,
+        far_z: Some(far_z),
     };
 
+    let scale_mat = Mat4::scaling_3d(scale);
+    let rot_mat = Mat4::from(rotation);
+    let trans_mat = Mat4::translation_3d(position);
+
     Camera {
-        view: Mat4::look_at_rh(eye, target, Vec3::up()),
+        view: (trans_mat * rot_mat * scale_mat).inverted(),
         projection: cam_type.to_projection(),
     }
 }
-
 
 register_module!(mut cx, {
     cx.export_function("render_sprite", render_sprite)?;

--- a/spritec_gui/components/Import/CameraList.js
+++ b/spritec_gui/components/Import/CameraList.js
@@ -1,0 +1,39 @@
+const Component = require('../../lib/Component');
+const {loadCamera} = require('./actions');
+
+class CameraList extends Component {
+  onCreate(element) {
+    this.state = {
+      listElement: element,
+    }
+    this.state.listElement.onchange = (event) => {
+      this.dispatch(loadCamera(event.target.value));
+    }
+  }
+
+  mapStateToProps() {
+    return {
+      cameras: state => state.import.selected.cameras,
+      cameraName: state => state.import.selected.camera.name,
+      useCustomCamera: state => state.import.useCustomCamera,
+    };
+  }
+
+  render() {
+    const {cameras, cameraName, useCustomCamera} = this.props;
+    const {listElement} = this.state;
+
+    // clear the list
+    listElement.innerHTML = '';
+
+    listElement.disabled = (cameras.length == 0 || useCustomCamera);
+    cameras.forEach(camera => listElement.add(new Option(
+      camera, // text
+      camera, // value
+      false,  // default selected
+      camera === cameraName // selected
+    )));
+  }
+}
+
+module.exports = CameraList;

--- a/spritec_gui/components/Import/CameraList.js
+++ b/spritec_gui/components/Import/CameraList.js
@@ -7,31 +7,32 @@ class CameraList extends Component {
       listElement: element,
     }
     this.state.listElement.onchange = (event) => {
-      this.dispatch(loadCamera(event.target.value));
+      this.dispatch(loadCamera(Number(event.target.value)));
     }
   }
 
   mapStateToProps() {
     return {
       cameras: state => state.import.selected.cameras,
-      cameraName: state => state.import.selected.camera.name,
+      cameraId: state => state.import.selected.camera.id,
       useCustomCamera: state => state.import.useCustomCamera,
     };
   }
 
   render() {
-    const {cameras, cameraName, useCustomCamera} = this.props;
+    const {cameras, cameraId, useCustomCamera} = this.props;
     const {listElement} = this.state;
 
     // clear the list
     listElement.innerHTML = '';
 
+    console.log(cameras);
     listElement.disabled = (cameras.length == 0 || useCustomCamera);
     cameras.forEach(camera => listElement.add(new Option(
-      camera, // text
-      camera, // value
+      camera.name, // text
+      camera.id, // value
       false,  // default selected
-      camera === cameraName // selected
+      camera.id === cameraId // selected
     )));
   }
 }

--- a/spritec_gui/components/Import/ImportCanvas.js
+++ b/spritec_gui/components/Import/ImportCanvas.js
@@ -2,15 +2,23 @@ const spritec = require('spritec_binding');
 const Component = require('../../lib/Component');
 
 class ImportCanvas extends Component {
-  onCreate(canvas) {
+  onCreate(container) {
+    const canvas = container.querySelector('#spritec-canvas');
     this.state = {
       canvas,
       ctx: canvas.getContext('2d'),
     };
     this.state.ctx.imageSmoothingEnabled = false;
 
-    // TODO: Allow scaling with CSS with `image-rendering: pixelated`, see
-    // https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event
+    canvas.style.transform = `scale(8)`;
+
+    let scale = 8;
+    container.onwheel = (event) => {
+      event.preventDefault();
+      scale += event.deltaY * -0.01;
+      scale = Math.max(0.125, scale);
+      this.state.canvas.style.transform = `scale(${scale})`;
+    }
   }
 
   mapStateToProps() {
@@ -22,8 +30,8 @@ class ImportCanvas extends Component {
   }
 
   render() {
-    const { canvas, ctx } = this.state;
-    const { width, height, file } = this.props;
+    const {canvas, ctx} = this.state;
+    const {width, height, file} = this.props;
 
     canvas.width = width;
     canvas.height = height;

--- a/spritec_gui/components/Import/ImportCanvas.js
+++ b/spritec_gui/components/Import/ImportCanvas.js
@@ -23,27 +23,36 @@ class ImportCanvas extends Component {
 
   mapStateToProps() {
     return {
-      width: (state) => state.import.width,
-      height: (state) => state.import.height,
-      file: (state) => state.import.selectedFile,
+      width: (state) => state.import.selected.width,
+      height: (state) => state.import.selected.height,
+      path: (state) => state.import.selected.path,
+      camera: (state) => state.import.selected.camera,
     };
   }
 
   render() {
     const {canvas, ctx} = this.state;
-    const {width, height, file} = this.props;
+    const {width, height, path, camera} = this.props;
 
     canvas.width = width;
     canvas.height = height;
 
-    if (file === null) return;
+    if (path === null) return;
 
     // TODO: use offscreen canvas when calling spritec
     let imageBuffer = new Uint8ClampedArray(spritec.render_sprite(
-      file,
+      path,
       width,
-      height
+      height,
+      new Float32Array(camera.position).buffer,
+      new Float32Array(camera.rotation).buffer,
+      new Float32Array(camera.scale).buffer,
+      camera.aspect_ratio,
+      camera.near_z,
+      camera.far_z,
+      camera.fov,
     ));
+
     let imageData = new ImageData(imageBuffer, width);
 
     createImageBitmap(imageData).then((bitmap) => {

--- a/spritec_gui/components/Import/ImportPanel.js
+++ b/spritec_gui/components/Import/ImportPanel.js
@@ -17,8 +17,8 @@ class ImportPanel extends Component {
 
   mapStateToProps() {
     return {
-      width: (state) => state.import.width,
-      height: (state) => state.import.height,
+      width: (state) => state.import.selected.width,
+      height: (state) => state.import.selected.height,
     };
   }
 

--- a/spritec_gui/components/Import/ModelList.js
+++ b/spritec_gui/components/Import/ModelList.js
@@ -2,6 +2,7 @@ const {dialog} = require('electron').remote;
 const {basename} = require('path');
 
 const {actions} = require('./slice');
+const {loadGLTF} = require('./actions');
 const Component = require('../../lib/Component');
 
 class ModelList extends Component {
@@ -12,7 +13,7 @@ class ModelList extends Component {
     }
 
     this.state.selectElement.onchange = (event) => {
-      this.dispatch(actions.selectFile(event.target.value));
+      this.dispatch(loadGLTF(event.target.value));
     }
 
     element.querySelector('#spritec-model-add').onclick = (event) => {
@@ -24,7 +25,7 @@ class ModelList extends Component {
         filters: [{name: 'Models', extensions: ['glb', 'gltf']}]
       }).then(({filePaths}) => {
         if (filePaths.length === 0) return;
-        this.dispatch(actions.addFile(filePaths[0]));
+        this.dispatch(loadGLTF(filePaths[0]));
       });
     }
   }
@@ -32,7 +33,7 @@ class ModelList extends Component {
   mapStateToProps() {
     return {
       files: (state) => state.import.files,
-      selectedFile: (state) => state.import.selectedFile,
+      selectedFile: (state) => state.import.selected.path,
     }
   }
 

--- a/spritec_gui/components/Import/actions.js
+++ b/spritec_gui/components/Import/actions.js
@@ -20,9 +20,12 @@ const loadGLTF = path => dispatch => {
       scene = gltf.scene;
 
       // load the camera info first before loading the model
-      const cameras = gltf.cameras.map(camera => camera.name);
+      const cameras = gltf.cameras.map(camera => ({
+        id: camera.id,
+        name: parseCameraName(camera),
+      }));
       if (cameras.length > 0) {
-        dispatch(loadCamera(cameras[0]));
+        dispatch(loadCamera(cameras[0].id));
       }
 
       dispatch(actions.loadModel({path, cameras}));
@@ -32,15 +35,15 @@ const loadGLTF = path => dispatch => {
   );
 };
 
-const loadCamera = cameraName => dispatch => {
-  let cameraObj = scene.getObjectByName(cameraName);
+const loadCamera = id => dispatch => {
+  let cameraObj = scene.getObjectById(id);
   // Render the scene with the camera so that the camera properties are
   // updated with respect to the world.
   renderer.render(scene, cameraObj);
   cameraObj.matrixWorld.decompose(position, rotation, scale);
 
   dispatch(actions.setCamera({
-    name: cameraName,
+    id,
     position: position.toArray(),
     rotation: rotation.toArray(),
     scale: scale.toArray(),
@@ -51,6 +54,31 @@ const loadCamera = cameraName => dispatch => {
     fov: cameraObj.fov,
   }));
 };
+
+/*
+ * Parses the camera name from a camera object. The name depends on what meta information
+ * is available. The precedence is:
+ *
+ * 1. cameraName (parentName)
+ * 2. cameraName
+ * 3. parentName
+ * 4. threeID
+ */
+const parseCameraName = cameraObj => {
+  if (cameraObj.name && cameraObj.parent && cameraObj.parent.name) {
+    return `${cameraObj.name} (${cameraObj.parent.name})`;
+  }
+
+  if (cameraObj.name) {
+    return cameraObj.name;
+  }
+
+  if (cameraObj.parent && cameraObj.parent.name) {
+    return cameraObj.parent.name;
+  }
+
+  return `Camera_${cameraObj.id}`;
+}
 
 module.exports = {
   loadGLTF,

--- a/spritec_gui/components/Import/actions.js
+++ b/spritec_gui/components/Import/actions.js
@@ -1,0 +1,58 @@
+const {actions} = require('./slice');
+const THREE = require('three');
+// We don't support ES6 import statements, so have to bring THREE into window
+// scope and require the GLTFLoader separately.
+window.THREE = THREE;
+require('three/examples/js/loaders/GLTFLoader.js');
+
+// Reuse the same renderer
+const renderer = new THREE.WebGLRenderer();
+let scene = null;
+let position = new THREE.Vector3();
+let rotation = new THREE.Quaternion();
+let scale = new THREE.Vector3();
+
+const loadGLTF = path => dispatch => {
+  const loader = new THREE.GLTFLoader();
+  loader.load(path,
+    (gltf) => {
+      // Cache the scene outside of redux
+      scene = gltf.scene;
+
+      // load the camera info first before loading the model
+      const cameras = gltf.cameras.map(camera => camera.name);
+      if (cameras.length > 0) {
+        dispatch(loadCamera(cameras[0]));
+      }
+
+      dispatch(actions.loadModel({path, cameras}));
+    },
+    null, // onProgress
+    err => console.error(err),
+  );
+};
+
+const loadCamera = cameraName => dispatch => {
+  let cameraObj = scene.getObjectByName(cameraName);
+  // Render the scene with the camera so that the camera properties are
+  // updated with respect to the world.
+  renderer.render(scene, cameraObj);
+  cameraObj.matrixWorld.decompose(position, rotation, scale);
+
+  dispatch(actions.setCamera({
+    name: cameraName,
+    position: position.toArray(),
+    rotation: rotation.toArray(),
+    scale: scale.toArray(),
+    // TODO: handle non-perspective cameras
+    aspect_ratio: cameraObj.aspect,
+    near_z: cameraObj.near,
+    far_z: cameraObj.far,
+    fov: cameraObj.fov,
+  }));
+};
+
+module.exports = {
+  loadGLTF,
+  loadCamera,
+};

--- a/spritec_gui/components/Import/slice.js
+++ b/spritec_gui/components/Import/slice.js
@@ -5,8 +5,8 @@ const importReducer = createSlice({
   initialState: {
     files: [],
     selectedFile: null,
-    width: 256,
-    height: 256,
+    width: 64,
+    height: 64,
   },
   reducers: {
     setWidth(state, action) { state.width = action.payload },

--- a/spritec_gui/components/Import/slice.js
+++ b/spritec_gui/components/Import/slice.js
@@ -1,22 +1,45 @@
-const { createSlice } = require('@reduxjs/toolkit');
+const {createSlice} = require('@reduxjs/toolkit');
 
-const importReducer = createSlice({
+const importSlice = createSlice({
   name: 'import',
   initialState: {
+    selected: {
+      path: null, // file path of selected model
+      cameras: [], // list of camera names for this model
+      camera: {
+        name: null,
+        position: [0, 0, 0],
+        rotation: [0, 0, 0, 1], // quaternion
+        scale: [1, 1, 1],
+        aspect_ratio: 1,
+        near_z: 0.1,
+        far_z: 2000,
+        fov: 50, // field of view (from bottom to top, in degrees)
+      },
+      width: 64,
+      height: 64,
+    },
+    useCustomCamera: false,
     files: [],
-    selectedFile: null,
-    width: 64,
-    height: 64,
   },
   reducers: {
-    setWidth(state, action) { state.width = action.payload },
-    setHeight(state, action) { state.height = action.payload },
-    addFile(state, action) {
-      state.files.push(action.payload);
-      state.selectedFile = action.payload;
+    setWidth(state, action) {state.selected.width = action.payload},
+    setHeight(state, action) {state.selected.height = action.payload},
+    loadModel(state, action) {
+      const {path, cameras} = action.payload;
+      // Convert to a set and convert back to array. This way if we load the
+      // same model twice we won't have duplicate entries.
+      state.files = Array.from(new Set(state.files).add(path))
+      state.selected.path = path;
+
+      // If no cameras then enable custom camera
+      state.useCustomCamera = (cameras.length === 0);
+      state.selected.cameras = cameras;
     },
-    selectFile(state, action) { state.selectedFile = action.payload },
+    setCamera(state, action) {
+      state.selected.camera = action.payload;
+    }
   }
 })
 
-module.exports = importReducer;
+module.exports = importSlice;

--- a/spritec_gui/components/Import/slice.js
+++ b/spritec_gui/components/Import/slice.js
@@ -5,9 +5,9 @@ const importSlice = createSlice({
   initialState: {
     selected: {
       path: null, // file path of selected model
-      cameras: [], // list of camera names for this model
+      cameras: [], // list of camera {id, name}
       camera: {
-        name: null,
+        id: null,
         position: [0, 0, 0],
         rotation: [0, 0, 0, 1], // quaternion
         scale: [1, 1, 1],

--- a/spritec_gui/css/main.css
+++ b/spritec_gui/css/main.css
@@ -20,6 +20,7 @@
 
 #spritec-canvas {
   background-image: url('../assets/transparent-bg.svg');
+  image-rendering: pixelated;
 }
 
 #import-panel {

--- a/spritec_gui/index.js
+++ b/spritec_gui/index.js
@@ -5,6 +5,9 @@ const { app, BrowserWindow } = require('electron')
 let win
 
 function createWindow () {
+  // Some plugins read from NODE_ENV for optimizations
+  process.env.NODE_ENV = app.isPackaged ? 'production' : 'development'
+
   // Create the browser window.
   win = new BrowserWindow({
     width: 1024,

--- a/spritec_gui/main.html
+++ b/spritec_gui/main.html
@@ -19,7 +19,7 @@
       <div id="spritec-container" class="uk-width-expand">
         <canvas id="spritec-canvas" width="512" height="512"></canvas>
       </div>
-      <div class="uk-width-auto uk-padding-remove" id="import-panel">
+      <div class="uk-width-medium uk-padding-remove" id="import-panel">
         <form id="spritec-import">
           <fieldset class="uk-fieldset">
             <h4 class="uk-padding-small uk-margin-remove uk-text-center">Import model</h4>

--- a/spritec_gui/main.html
+++ b/spritec_gui/main.html
@@ -52,8 +52,7 @@
             <div class="uk-padding-small">
               <label class="uk-form-label">Camera</label>
               <div class="uk-form-controls">
-                <select class="uk-select">
-                  <option>TODO</option>
+                <select disabled id="spritec-camera-list" class="uk-select">
                 </select>
               </div>
             </div>

--- a/spritec_gui/main.js
+++ b/spritec_gui/main.js
@@ -1,8 +1,9 @@
+const CameraList = require('./components/Import/CameraList');
 const ImportCanvas = require('./components/Import/ImportCanvas');
 const ImportPanel = require('./components/Import/ImportPanel');
 const importSlice = require('./components/Import/slice');
 const ModelList = require('./components/Import/ModelList');
-const { configureStore } = require('@reduxjs/toolkit');
+const {configureStore} = require('@reduxjs/toolkit');
 
 const store = configureStore({
   reducer: {
@@ -14,6 +15,7 @@ let components = [
   new ImportCanvas(document.querySelector('#spritec-container'), store),
   new ImportPanel(document.querySelector('#spritec-import'), store),
   new ModelList(document.querySelector('#spritec-model-list'), store),
+  new CameraList(document.querySelector('#spritec-camera-list'), store),
 ];
 
 store.subscribe(() => {

--- a/spritec_gui/main.js
+++ b/spritec_gui/main.js
@@ -11,7 +11,7 @@ const store = configureStore({
 });
 
 let components = [
-  new ImportCanvas(document.querySelector('#spritec-canvas'), store),
+  new ImportCanvas(document.querySelector('#spritec-container'), store),
   new ImportPanel(document.querySelector('#spritec-import'), store),
   new ModelList(document.querySelector('#spritec-model-list'), store),
 ];

--- a/spritec_gui/package-lock.json
+++ b/spritec_gui/package-lock.json
@@ -3242,6 +3242,11 @@
         }
       }
     },
+    "three": {
+      "version": "0.113.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.113.2.tgz",
+      "integrity": "sha512-x3vrKW41/UtbWbWduWKGlfIc043SvHWr3YltehYq+UGb9YglQ2oztNGvl2eut05JtNSmP11Mh3t6Xak5/0e+Fg=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",

--- a/spritec_gui/package.json
+++ b/spritec_gui/package.json
@@ -35,7 +35,8 @@
   "homepage": "https://protoart.me",
   "dependencies": {
     "@reduxjs/toolkit": "^1.2.3",
-    "spritec_binding": "file:../spritec_binding"
+    "spritec_binding": "file:../spritec_binding",
+    "three": "^0.113.2"
   },
   "devDependencies": {
     "electron": "^7.1.9",


### PR DESCRIPTION
This PR implements
- zooming on the canvas
- read and select camera from GLTF (part of #142)

The camera selection is done by reading the camera data from three.js and passing it into spritec.
This will allow us to easily implement external/custom camera later. It exposes the same format to the user as unity (position, rotation, scaling).

![screen](https://user-images.githubusercontent.com/15278132/74699854-c5fd1880-51cf-11ea-9196-d5b6ee10fa40.gif)
