### PR TITLE
Ability to query lights by name

### DIFF
--- a/spritec_binding/native/src/lib.rs
+++ b/spritec_binding/native/src/lib.rs
@@ -465,6 +465,7 @@ fn create_camera(
 fn default_lights() -> Arc<Vec<Arc<Light>>> {
     Arc::new(vec![Arc::new(Light {
         data: Arc::new(LightType::Directional {
+            name: None,
             color: Rgb::white(),
             intensity: 1.0,
         }),

--- a/src/query3d/backend.rs
+++ b/src/query3d/backend.rs
@@ -23,10 +23,8 @@ pub enum QueryError {
 
     #[error("Could not find animation named `{name}` in model file")]
     UnknownAnimation {name: String},
-
     #[error("Could not find any matching animation in model file")]
     NoAnimationFound,
-
     #[error("Multiple animations matched for a single node, please specify an animation name")]
     AmbiguousAnimation,
 
@@ -35,10 +33,11 @@ pub enum QueryError {
 
     #[error("Could not find camera named `{name}` in model file")]
     UnknownCamera {name: String},
-
     #[error("Could not find any matching cameras in model file")]
     NoCameraFound,
 
+    #[error("Could not find light named `{name}` in model file")]
+    UnknownLight {name: String},
     #[error("Could not find any matching lights in model file")]
     NoLightsFound,
 }

--- a/src/query3d/backend/obj.rs
+++ b/src/query3d/backend/obj.rs
@@ -111,8 +111,11 @@ impl QueryBackend for ObjFile {
         // This code still does the work to produce useful errors
         match query {
             LightQuery::Scene {name: None} => Err(QueryError::NoLightsFound),
+            LightQuery::Named {name, scene: None} => Err(QueryError::UnknownCamera {name: name.clone()}),
+
             // OBJ files do not contain any named scenes
-            LightQuery::Scene {name: Some(name)} => Err(QueryError::UnknownScene {
+            LightQuery::Scene {name: Some(name)} |
+            LightQuery::Named {name: _, scene: Some(name)} => Err(QueryError::UnknownScene {
                 name: name.clone(),
             }),
         }

--- a/src/query3d/query.rs
+++ b/src/query3d/query.rs
@@ -75,6 +75,13 @@ pub enum LightQuery {
         /// The name of the scene to look in or None if the default scene should be used
         name: Option<String>,
     },
+    /// Returns the light with the given name
+    Named {
+        /// The name of the light to look for
+        name: String,
+        /// The name of the scene to look in or None if the default scene should be used
+        scene: Option<String>,
+    },
 }
 
 impl LightQuery {

--- a/src/renderer/shader/light_uniform.rs
+++ b/src/renderer/shader/light_uniform.rs
@@ -41,7 +41,7 @@ impl LightUniform {
 
         use LightType::*;
         match light {
-            Point {color, intensity, range} => Self {
+            Point {name: _, color, intensity, range} => Self {
                 position: UniformValue::Vec4([pos.x, pos.y, pos.z, 1.0]),
                 color: UniformValue::Vec3((color * intensity).into_array()),
                 range: UniformValue::Float(range.unwrap_or(0.0)),
@@ -50,7 +50,7 @@ impl LightUniform {
                 light_angle_offset: UniformValue::Float(0.0),
             },
 
-            Directional {color, intensity} => Self {
+            Directional {name: _, color, intensity} => Self {
                 position: UniformValue::Vec4([direction.x, direction.y, direction.z, 0.0]),
                 color: UniformValue::Vec3((color * intensity).into_array()),
                 range: UniformValue::Float(0.0),
@@ -59,7 +59,7 @@ impl LightUniform {
                 light_angle_offset: UniformValue::Float(0.0),
             },
 
-            Spot {color, intensity, range, inner_cone_angle, outer_cone_angle} => {
+            Spot {name: _, color, intensity, range, inner_cone_angle, outer_cone_angle} => {
                 // cos() expects a value in radians
                 let inner_cone_angle = inner_cone_angle.get_radians();
                 let outer_cone_angle = outer_cone_angle.get_radians();

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -114,6 +114,7 @@ pub fn generate_pose_task(
             //TODO: Figure out how we want to allow lights to be configured
             lights: RenderLights::Lights(Arc::new(vec![Arc::new(Light {
                 data: Arc::new(LightType::Directional {
+                    name: None,
                     color: Rgb::white(),
                     intensity: 1.0,
                 }),
@@ -174,6 +175,7 @@ pub fn generate_spritesheet_task(
                         //TODO: Figure out how we want to allow lights to be configured
                         lights: RenderLights::Lights(Arc::new(vec![Arc::new(Light {
                             data: Arc::new(LightType::Directional {
+                                name: None,
                                 color: Rgb::white(),
                                 intensity: 1.0,
                             }),
@@ -219,6 +221,7 @@ pub fn generate_spritesheet_task(
                         //TODO: Figure out how we want to allow lights to be configured
                         lights: RenderLights::Lights(Arc::new(vec![Arc::new(Light {
                             data: Arc::new(LightType::Directional {
+                                name: None,
                                 color: Rgb::white(),
                                 intensity: 1.0,
                             }),


### PR DESCRIPTION
This is some work I did during reading week. I didn't want to add any features at the time since we were preparing for a release, so I didn't end up making a PR at the time.

This PR adds the ability to query lights by name and use specific lights from a glTF file when rendering with spritec. The changes here are largely similar to #152, though this does **not** add support for querying lights from the config. This is a feature that is largely meant to be accessible through the UI and used in the showcase we're creating.

There is now a `LightQuery::Named {..}` that you can use to select a single light with the given name in a scene.